### PR TITLE
feat: Add Gotify and Apprise notification support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,11 @@ BIND_ADDRESS=0.0.0.0               # Server bind address (0.0.0.0 for all interf
 # Uncomment and configure webhook URLs for notifications
 # TEAMS_WEBHOOK_URL=https://your-org.webhook.office.com/webhookb2/...
 # SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...
+# GOTIFY_SERVER_URL=https://gotify.example.com
+# GOTIFY_APP_TOKEN=your-gotify-app-token
+# APPRISE_API_URL=https://apprise.example.com
+# APPRISE_CONFIG_KEY=optional-config-key
+# APPRISE_URLS=service://url1,service://url2  # Optional: specific notification URLs
 NOTIFY_ON_HIGH_SEVERITY=true       # Send notifications for high/critical findings only
 
 # Monitoring

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -22,6 +22,11 @@ export interface AppConfig {
   // Notifications
   teamsWebhookUrl?: string;
   slackWebhookUrl?: string;
+  gotifyServerUrl?: string;
+  gotifyAppToken?: string;
+  appriseApiUrl?: string;
+  appriseConfigKey?: string;
+  appriseUrls?: string;
   notifyOnHighSeverity: boolean;
   
   // Monitoring
@@ -57,6 +62,11 @@ function parseEnvConfig(): AppConfig {
     // Notifications
     teamsWebhookUrl: process.env.TEAMS_WEBHOOK_URL,
     slackWebhookUrl: process.env.SLACK_WEBHOOK_URL,
+    gotifyServerUrl: process.env.GOTIFY_SERVER_URL,
+    gotifyAppToken: process.env.GOTIFY_APP_TOKEN,
+    appriseApiUrl: process.env.APPRISE_API_URL,
+    appriseConfigKey: process.env.APPRISE_CONFIG_KEY,
+    appriseUrls: process.env.APPRISE_URLS,
     notifyOnHighSeverity: process.env.NOTIFY_ON_HIGH_SEVERITY?.toLowerCase() === 'true',
     
     // Monitoring
@@ -107,6 +117,28 @@ function validateConfig(config: AppConfig): void {
   
   if (config.enabledScanners.length === 0) {
     errors.push('At least one scanner must be enabled');
+  }
+  
+  // Validate Gotify configuration
+  if (config.gotifyServerUrl && !config.gotifyAppToken) {
+    errors.push('GOTIFY_APP_TOKEN is required when GOTIFY_SERVER_URL is set');
+  }
+  
+  if (config.gotifyAppToken && !config.gotifyServerUrl) {
+    errors.push('GOTIFY_SERVER_URL is required when GOTIFY_APP_TOKEN is set');
+  }
+  
+  if (config.gotifyServerUrl && !config.gotifyServerUrl.startsWith('http')) {
+    errors.push('GOTIFY_SERVER_URL must start with http:// or https://');
+  }
+  
+  // Validate Apprise configuration
+  if (config.appriseUrls && !config.appriseApiUrl) {
+    errors.push('APPRISE_API_URL is required when APPRISE_URLS is set');
+  }
+  
+  if (config.appriseApiUrl && !config.appriseApiUrl.startsWith('http')) {
+    errors.push('APPRISE_API_URL must start with http:// or https://');
   }
   
   if (errors.length > 0) {


### PR DESCRIPTION
## Summary
- Added support for Gotify server notifications with configurable priority levels based on severity
- Added support for Apprise API to enable flexible multi-service notification routing
- Extended notification configuration with proper validation for both services

## Changes
- **Updated `src/lib/config.ts`**: Added configuration fields for Gotify (server URL, app token) and Apprise (API URL, config key, URLs)
- **Enhanced `src/lib/notifications.ts`**: Implemented `sendGotifyNotification()` and `sendAppriseNotification()` methods with proper message formatting
- **Updated `.env.example`**: Added example environment variables for both notification services

## Configuration
### Gotify
```bash
GOTIFY_SERVER_URL=https://gotify.example.com
GOTIFY_APP_TOKEN=your-gotify-app-token
```

### Apprise
```bash
APPRISE_API_URL=https://apprise.example.com
APPRISE_CONFIG_KEY=optional-config-key  # For persistent configuration
APPRISE_URLS=service://url1,service://url2  # Direct notification URLs
```

## Features
- Priority levels automatically mapped based on vulnerability severity
- Markdown formatting support for rich notifications
- Respects existing `NOTIFY_ON_HIGH_SEVERITY` setting
- Seamless integration with existing Teams and Slack notifications
- All notifications sent in parallel for optimal performance

## Test Plan
- [x] Build passes without errors
- [ ] Test Gotify notifications with a live server
- [ ] Test Apprise notifications with various services
- [ ] Verify notifications only trigger for high/critical severities when configured
- [ ] Confirm parallel sending with other webhook services