### PR TITLE
Fix vulnerability URL routing with context menu for multiple links

### DIFF
--- a/src/app/image/[name]/scan/[scanId]/page.tsx
+++ b/src/app/image/[name]/scan/[scanId]/page.tsx
@@ -24,6 +24,7 @@ import {
 import { AppSidebar } from "@/components/app-sidebar";
 import { SiteHeader } from "@/components/site-header";
 import { Button } from "@/components/ui/button";
+import { VulnerabilityUrlMenu } from "@/components/vulnerability-url-menu";
 import {
   Card,
   CardContent,
@@ -1062,22 +1063,10 @@ export default function ScanResultsPage() {
                                           <IconX className="h-4 w-4" />
                                         </Button>
                                       )}
-                                      {vuln.references &&
-                                        vuln.references.length > 0 && (
-                                          <Button
-                                            variant="ghost"
-                                            size="sm"
-                                            asChild
-                                          >
-                                            <a
-                                              href={vuln.references[0]}
-                                              target="_blank"
-                                              rel="noopener noreferrer"
-                                            >
-                                              <IconExternalLink className="h-4 w-4" />
-                                            </a>
-                                          </Button>
-                                        )}
+                                      <VulnerabilityUrlMenu 
+                                        vulnerabilityId={vuln.VulnerabilityID}
+                                        references={vuln.references || vuln.References || []}
+                                      />
                                     </div>
                                   </TableCell>
                                   <TableCell>
@@ -1270,22 +1259,10 @@ export default function ScanResultsPage() {
                                       <IconX className="h-4 w-4" />
                                     </Button>
                                   )}
-                                  {match.vulnerability.urls &&
-                                    match.vulnerability.urls.length > 0 && (
-                                      <Button
-                                        variant="ghost"
-                                        size="sm"
-                                        asChild
-                                      >
-                                        <a
-                                          href={match.vulnerability.urls[0]}
-                                          target="_blank"
-                                          rel="noopener noreferrer"
-                                        >
-                                          <IconExternalLink className="h-4 w-4" />
-                                        </a>
-                                      </Button>
-                                    )}
+                                  <VulnerabilityUrlMenu 
+                                    vulnerabilityId={match.vulnerability.id}
+                                    references={match.vulnerability.urls || []}
+                                  />
                                 </div>
                               </TableCell>
                               <TableCell>

--- a/src/app/library/[name]/page.tsx
+++ b/src/app/library/[name]/page.tsx
@@ -16,6 +16,7 @@ import {
 import { AppSidebar } from "@/components/app-sidebar"
 import { SiteHeader } from "@/components/site-header"
 import { Button } from "@/components/ui/button"
+import { VulnerabilityUrlMenu } from "@/components/vulnerability-url-menu"
 import {
   Card,
   CardContent,
@@ -495,20 +496,10 @@ export default function LibraryDetailsPage() {
                                 </Badge>
                               </TableCell>
                               <TableCell>
-                                <div className="flex items-center gap-2">
-                                  {vuln.references && vuln.references.length > 0 && (
-                                    <Button variant="ghost" size="sm" asChild>
-                                      <a
-                                        href={vuln.references[0]}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        title="View CVE details"
-                                      >
-                                        <IconExternalLink className="h-4 w-4" />
-                                      </a>
-                                    </Button>
-                                  )}
-                                </div>
+                                <VulnerabilityUrlMenu 
+                                  vulnerabilityId={vuln.id}
+                                  references={vuln.references || []}
+                                />
                               </TableCell>
                             </TableRow>
                           ))}

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -1,7 +1,7 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import { useRouter } from "next/navigation"
+import * as React from "react";
+import { useRouter } from "next/navigation";
 import {
   IconPackage,
   IconBug,
@@ -13,23 +13,21 @@ import {
   IconExternalLink,
   IconX,
   IconCheck,
-} from "@tabler/icons-react"
+} from "@tabler/icons-react";
 
-import { AppSidebar } from "@/components/app-sidebar"
-import { SiteHeader } from "@/components/site-header"
-import { Button } from "@/components/ui/button"
+import { AppSidebar } from "@/components/app-sidebar";
+import { SiteHeader } from "@/components/site-header";
+import { Button } from "@/components/ui/button";
+import { VulnerabilityUrlMenu } from "@/components/vulnerability-url-menu";
 import {
   Card,
   CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
-} from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
-import {
-  SidebarInset,
-  SidebarProvider,
-} from "@/components/ui/sidebar"
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import {
   Table,
   TableBody,
@@ -37,165 +35,188 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from "@/components/ui/table"
-import { Input } from "@/components/ui/input"
+} from "@/components/ui/table";
+import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@/components/ui/select"
-import { FullPageLoading, StatsLoadingSkeleton, TableLoadingSkeleton } from "@/components/ui/loading"
+} from "@/components/ui/select";
+import {
+  FullPageLoading,
+  StatsLoadingSkeleton,
+  TableLoadingSkeleton,
+} from "@/components/ui/loading";
 
 interface VulnerabilityData {
-  cveId: string
-  severity: string
-  description?: string
-  cvssScore?: number
-  packageName?: string
+  cveId: string;
+  severity: string;
+  description?: string;
+  cvssScore?: number;
+  packageName?: string;
   affectedImages: Array<{
-    imageName: string
-    imageId: string
-    isFalsePositive: boolean
-  }>
-  totalAffectedImages: number
-  falsePositiveImages: string[]
-  fixedVersion?: string
-  publishedDate?: string
-  references?: string[]
+    imageName: string;
+    imageId: string;
+    isFalsePositive: boolean;
+  }>;
+  totalAffectedImages: number;
+  falsePositiveImages: string[];
+  fixedVersion?: string;
+  publishedDate?: string;
+  references?: string[];
 }
 
 export default function LibraryHomePage() {
-  const router = useRouter()
-  
-  const [vulnerabilities, setVulnerabilities] = React.useState<VulnerabilityData[]>([])
-  const [loading, setLoading] = React.useState(true)
-  const [search, setSearch] = React.useState("")
-  const [severityFilter, setSeverityFilter] = React.useState<string>("")
-  const [sortField, setSortField] = React.useState<string>("severity")
-  const [sortOrder, setSortOrder] = React.useState<"asc" | "desc">("desc")
+  const router = useRouter();
+
+  const [vulnerabilities, setVulnerabilities] = React.useState<
+    VulnerabilityData[]
+  >([]);
+  const [loading, setLoading] = React.useState(true);
+  const [search, setSearch] = React.useState("");
+  const [severityFilter, setSeverityFilter] = React.useState<string>("");
+  const [sortField, setSortField] = React.useState<string>("severity");
+  const [sortOrder, setSortOrder] = React.useState<"asc" | "desc">("desc");
   const [pagination, setPagination] = React.useState({
     total: 0,
     limit: 100,
     offset: 0,
-    hasMore: false
-  })
+    hasMore: false,
+  });
 
   // Fetch vulnerabilities from API
   const fetchVulnerabilities = React.useCallback(async () => {
     try {
-      setLoading(true)
+      setLoading(true);
       const params = new URLSearchParams({
         limit: pagination.limit.toString(),
         offset: pagination.offset.toString(),
-      })
-      
-      if (search) params.append('search', search)
-      if (severityFilter) params.append('severity', severityFilter)
-      
-      const response = await fetch(`/api/vulnerabilities?${params}`)
-      if (!response.ok) throw new Error('Failed to fetch vulnerabilities')
-      
-      const data = await response.json()
-      setVulnerabilities(data.vulnerabilities)
-      setPagination(data.pagination)
+      });
+
+      if (search) params.append("search", search);
+      if (severityFilter) params.append("severity", severityFilter);
+
+      const response = await fetch(`/api/vulnerabilities?${params}`);
+      if (!response.ok) throw new Error("Failed to fetch vulnerabilities");
+
+      const data = await response.json();
+      setVulnerabilities(data.vulnerabilities);
+      setPagination(data.pagination);
     } catch (error) {
-      console.error('Failed to fetch vulnerabilities:', error)
+      console.error("Failed to fetch vulnerabilities:", error);
     } finally {
-      setLoading(false)
+      setLoading(false);
     }
-  }, [search, severityFilter, pagination.limit, pagination.offset])
-  
+  }, [search, severityFilter, pagination.limit, pagination.offset]);
+
   React.useEffect(() => {
-    fetchVulnerabilities()
-  }, [fetchVulnerabilities])
+    fetchVulnerabilities();
+  }, [fetchVulnerabilities]);
 
   const sortedVulnerabilities = React.useMemo(() => {
     return [...vulnerabilities].sort((a, b) => {
-      let aValue: any, bValue: any
+      let aValue: any, bValue: any;
 
       switch (sortField) {
         case "cveId":
-          aValue = a.cveId
-          bValue = b.cveId
-          break
+          aValue = a.cveId;
+          bValue = b.cveId;
+          break;
         case "severity":
-          const severityPriority = { critical: 5, high: 4, medium: 3, low: 2, info: 1, unknown: 0 }
-          aValue = severityPriority[a.severity as keyof typeof severityPriority] || 0
-          bValue = severityPriority[b.severity as keyof typeof severityPriority] || 0
-          break
+          const severityPriority = {
+            critical: 5,
+            high: 4,
+            medium: 3,
+            low: 2,
+            info: 1,
+            unknown: 0,
+          };
+          aValue =
+            severityPriority[a.severity as keyof typeof severityPriority] || 0;
+          bValue =
+            severityPriority[b.severity as keyof typeof severityPriority] || 0;
+          break;
         case "cvssScore":
-          aValue = a.cvssScore || 0
-          bValue = b.cvssScore || 0
-          break
+          aValue = a.cvssScore || 0;
+          bValue = b.cvssScore || 0;
+          break;
         case "affectedImages":
-          aValue = a.totalAffectedImages
-          bValue = b.totalAffectedImages
-          break
+          aValue = a.totalAffectedImages;
+          bValue = b.totalAffectedImages;
+          break;
         case "falsePositives":
-          aValue = a.falsePositiveImages.length
-          bValue = b.falsePositiveImages.length
-          break
+          aValue = a.falsePositiveImages.length;
+          bValue = b.falsePositiveImages.length;
+          break;
         case "packageName":
-          aValue = a.packageName || ''
-          bValue = b.packageName || ''
-          break
+          aValue = a.packageName || "";
+          bValue = b.packageName || "";
+          break;
         default:
-          return 0
+          return 0;
       }
 
       if (sortOrder === "asc") {
-        return aValue > bValue ? 1 : -1
+        return aValue > bValue ? 1 : -1;
       } else {
-        return aValue < bValue ? 1 : -1
+        return aValue < bValue ? 1 : -1;
       }
-    })
-  }, [vulnerabilities, sortField, sortOrder])
+    });
+  }, [vulnerabilities, sortField, sortOrder]);
 
   const handleSort = (field: string) => {
     if (sortField === field) {
-      setSortOrder(sortOrder === "asc" ? "desc" : "asc")
+      setSortOrder(sortOrder === "asc" ? "desc" : "asc");
     } else {
-      setSortField(field)
-      setSortOrder("desc")
+      setSortField(field);
+      setSortOrder("desc");
     }
-  }
+  };
 
-  const handleRowClick = (cveId: string) => {
-    // Could navigate to a CVE detail page in the future
-    window.open(`https://nvd.nist.gov/vuln/detail/${cveId}`, '_blank')
-  }
-
-  const getSeverityColor = (severity: 'critical' | 'high' | 'medium' | 'low') => {
+  const getSeverityColor = (
+    severity: "critical" | "high" | "medium" | "low"
+  ) => {
     switch (severity) {
       case "critical":
-        return "destructive"
+        return "destructive";
       case "high":
-        return "destructive"
+        return "destructive";
       case "medium":
-        return "secondary"
+        return "secondary";
       case "low":
-        return "outline"
+        return "outline";
       default:
-        return "outline"
+        return "outline";
     }
-  }
+  };
 
   const breadcrumbs = [
     { label: "Dashboard", href: "/" },
-    { label: "Vulnerability Library" }
-  ]
+    { label: "Vulnerability Library" },
+  ];
 
   // Calculate overall statistics
   const stats = React.useMemo(() => {
-    const totalCves = vulnerabilities.length
-    const criticalCves = vulnerabilities.filter(v => v.severity === 'critical').length
-    const highCves = vulnerabilities.filter(v => v.severity === 'high').length
-    const fixableCves = vulnerabilities.filter(v => v.fixedVersion).length
-    const totalFalsePositives = vulnerabilities.reduce((sum, v) => sum + v.falsePositiveImages.length, 0)
-    const cvesWithFalsePositives = vulnerabilities.filter(v => v.falsePositiveImages.length > 0).length
-    const highRiskCves = vulnerabilities.filter(v => (v.cvssScore || 0) >= 7.0).length
+    const totalCves = vulnerabilities.length;
+    const criticalCves = vulnerabilities.filter(
+      (v) => v.severity === "critical"
+    ).length;
+    const highCves = vulnerabilities.filter(
+      (v) => v.severity === "high"
+    ).length;
+    const fixableCves = vulnerabilities.filter((v) => v.fixedVersion).length;
+    const totalFalsePositives = vulnerabilities.reduce(
+      (sum, v) => sum + v.falsePositiveImages.length,
+      0
+    );
+    const cvesWithFalsePositives = vulnerabilities.filter(
+      (v) => v.falsePositiveImages.length > 0
+    ).length;
+    const highRiskCves = vulnerabilities.filter(
+      (v) => (v.cvssScore || 0) >= 7.0
+    ).length;
 
     return {
       totalCves,
@@ -205,9 +226,10 @@ export default function LibraryHomePage() {
       totalFalsePositives,
       cvesWithFalsePositives,
       highRiskCves,
-      fixablePercent: totalCves > 0 ? Math.round((fixableCves / totalCves) * 100) : 0
-    }
-  }, [vulnerabilities])
+      fixablePercent:
+        totalCves > 0 ? Math.round((fixableCves / totalCves) * 100) : 0,
+    };
+  }, [vulnerabilities]);
 
   if (loading) {
     return (
@@ -227,7 +249,7 @@ export default function LibraryHomePage() {
               <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6 px-4 lg:px-6">
                 {/* Stats skeleton */}
                 <StatsLoadingSkeleton />
-                
+
                 {/* Table skeleton */}
                 <Card>
                   <CardHeader>
@@ -242,10 +264,7 @@ export default function LibraryHomePage() {
                     </CardDescription>
                   </CardHeader>
                   <CardContent>
-                    <TableLoadingSkeleton
-                      columns={8}
-                      rows={10}
-                    />
+                    <TableLoadingSkeleton columns={8} rows={10} />
                   </CardContent>
                 </Card>
               </div>
@@ -253,7 +272,7 @@ export default function LibraryHomePage() {
           </div>
         </SidebarInset>
       </SidebarProvider>
-    )
+    );
   }
 
   return (
@@ -271,7 +290,6 @@ export default function LibraryHomePage() {
         <div className="flex flex-1 flex-col">
           <div className="@container/main flex flex-1 flex-col gap-2 overflow-auto">
             <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6 px-4 lg:px-6">
-
               {/* Vulnerability Overview Stats */}
               <Card>
                 <CardHeader>
@@ -280,38 +298,59 @@ export default function LibraryHomePage() {
                     Vulnerability Library Overview
                   </CardTitle>
                   <CardDescription>
-                    All vulnerabilities across scanned images with false positive tracking
+                    All vulnerabilities across scanned images with false
+                    positive tracking
                   </CardDescription>
                 </CardHeader>
                 <CardContent>
                   <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-4">
                     <div className="text-center">
                       <p className="text-2xl font-bold">{stats.totalCves}</p>
-                      <p className="text-sm text-muted-foreground">Total CVEs</p>
+                      <p className="text-sm text-muted-foreground">
+                        Total CVEs
+                      </p>
                     </div>
                     <div className="text-center">
-                      <p className="text-2xl font-bold text-red-600">{stats.criticalCves}</p>
+                      <p className="text-2xl font-bold text-red-600">
+                        {stats.criticalCves}
+                      </p>
                       <p className="text-sm text-muted-foreground">Critical</p>
                     </div>
                     <div className="text-center">
-                      <p className="text-2xl font-bold text-orange-600">{stats.highCves}</p>
+                      <p className="text-2xl font-bold text-orange-600">
+                        {stats.highCves}
+                      </p>
                       <p className="text-sm text-muted-foreground">High</p>
                     </div>
                     <div className="text-center">
-                      <p className="text-2xl font-bold text-orange-600">{stats.highRiskCves}</p>
-                      <p className="text-sm text-muted-foreground">High CVSS (≥7.0)</p>
+                      <p className="text-2xl font-bold text-orange-600">
+                        {stats.highRiskCves}
+                      </p>
+                      <p className="text-sm text-muted-foreground">
+                        High CVSS (≥7.0)
+                      </p>
                     </div>
                     <div className="text-center">
-                      <p className="text-2xl font-bold text-green-600">{stats.fixableCves}</p>
+                      <p className="text-2xl font-bold text-green-600">
+                        {stats.fixableCves}
+                      </p>
                       <p className="text-sm text-muted-foreground">Fixable</p>
                     </div>
                     <div className="text-center">
-                      <p className="text-2xl font-bold text-purple-600">{stats.cvesWithFalsePositives}</p>
-                      <p className="text-sm text-muted-foreground">With False Positives</p>
+                      <p className="text-2xl font-bold text-purple-600">
+                        {stats.cvesWithFalsePositives}
+                      </p>
+                      <p className="text-sm text-muted-foreground">
+                        With False Positives
+                      </p>
                     </div>
                     <div className="text-center">
-                      <p className="text-2xl font-bold text-blue-600">{stats.fixablePercent}%</p>
-                      <p className="text-sm text-muted-foreground">Fixable Rate</p>
+                      <p className="text-2xl font-bold text-blue-600">
+                        {stats.fixablePercent}%
+                      </p>
+                      <p className="text-sm text-muted-foreground">
+                        Fixable Rate
+                      </p>
                     </div>
                   </div>
                 </CardContent>
@@ -325,7 +364,8 @@ export default function LibraryHomePage() {
                     Vulnerability Library
                   </CardTitle>
                   <CardDescription>
-                    All vulnerabilities found across scanned images with false positive tracking
+                    All vulnerabilities found across scanned images with false
+                    positive tracking
                   </CardDescription>
                 </CardHeader>
                 <CardContent>
@@ -341,7 +381,12 @@ export default function LibraryHomePage() {
                           className="pl-10"
                         />
                       </div>
-                      <Select value={severityFilter || "all"} onValueChange={(value) => setSeverityFilter(value === "all" ? "" : value)}>
+                      <Select
+                        value={severityFilter || "all"}
+                        onValueChange={(value) =>
+                          setSeverityFilter(value === "all" ? "" : value)
+                        }
+                      >
                         <SelectTrigger className="w-32">
                           <SelectValue placeholder="Severity" />
                         </SelectTrigger>
@@ -370,9 +415,12 @@ export default function LibraryHomePage() {
                                 onClick={() => handleSort("cveId")}
                               >
                                 CVE ID
-                                {sortField === "cveId" && (
-                                  sortOrder === "asc" ? <IconSortAscending className="ml-1 h-4 w-4" /> : <IconSortDescending className="ml-1 h-4 w-4" />
-                                )}
+                                {sortField === "cveId" &&
+                                  (sortOrder === "asc" ? (
+                                    <IconSortAscending className="ml-1 h-4 w-4" />
+                                  ) : (
+                                    <IconSortDescending className="ml-1 h-4 w-4" />
+                                  ))}
                               </Button>
                             </TableHead>
                             <TableHead>
@@ -382,11 +430,15 @@ export default function LibraryHomePage() {
                                 onClick={() => handleSort("severity")}
                               >
                                 Severity
-                                {sortField === "severity" && (
-                                  sortOrder === "asc" ? <IconSortAscending className="ml-1 h-4 w-4" /> : <IconSortDescending className="ml-1 h-4 w-4" />
-                                )}
+                                {sortField === "severity" &&
+                                  (sortOrder === "asc" ? (
+                                    <IconSortAscending className="ml-1 h-4 w-4" />
+                                  ) : (
+                                    <IconSortDescending className="ml-1 h-4 w-4" />
+                                  ))}
                               </Button>
                             </TableHead>
+                            <TableHead>Actions</TableHead>
                             <TableHead>
                               <Button
                                 variant="ghost"
@@ -394,9 +446,12 @@ export default function LibraryHomePage() {
                                 onClick={() => handleSort("cvssScore")}
                               >
                                 CVSS Score
-                                {sortField === "cvssScore" && (
-                                  sortOrder === "asc" ? <IconSortAscending className="ml-1 h-4 w-4" /> : <IconSortDescending className="ml-1 h-4 w-4" />
-                                )}
+                                {sortField === "cvssScore" &&
+                                  (sortOrder === "asc" ? (
+                                    <IconSortAscending className="ml-1 h-4 w-4" />
+                                  ) : (
+                                    <IconSortDescending className="ml-1 h-4 w-4" />
+                                  ))}
                               </Button>
                             </TableHead>
                             <TableHead>
@@ -406,9 +461,12 @@ export default function LibraryHomePage() {
                                 onClick={() => handleSort("packageName")}
                               >
                                 Package
-                                {sortField === "packageName" && (
-                                  sortOrder === "asc" ? <IconSortAscending className="ml-1 h-4 w-4" /> : <IconSortDescending className="ml-1 h-4 w-4" />
-                                )}
+                                {sortField === "packageName" &&
+                                  (sortOrder === "asc" ? (
+                                    <IconSortAscending className="ml-1 h-4 w-4" />
+                                  ) : (
+                                    <IconSortDescending className="ml-1 h-4 w-4" />
+                                  ))}
                               </Button>
                             </TableHead>
                             <TableHead>
@@ -418,9 +476,12 @@ export default function LibraryHomePage() {
                                 onClick={() => handleSort("affectedImages")}
                               >
                                 Affected Images
-                                {sortField === "affectedImages" && (
-                                  sortOrder === "asc" ? <IconSortAscending className="ml-1 h-4 w-4" /> : <IconSortDescending className="ml-1 h-4 w-4" />
-                                )}
+                                {sortField === "affectedImages" &&
+                                  (sortOrder === "asc" ? (
+                                    <IconSortAscending className="ml-1 h-4 w-4" />
+                                  ) : (
+                                    <IconSortDescending className="ml-1 h-4 w-4" />
+                                  ))}
                               </Button>
                             </TableHead>
                             <TableHead>
@@ -430,56 +491,110 @@ export default function LibraryHomePage() {
                                 onClick={() => handleSort("falsePositives")}
                               >
                                 False Positives
-                                {sortField === "falsePositives" && (
-                                  sortOrder === "asc" ? <IconSortAscending className="ml-1 h-4 w-4" /> : <IconSortDescending className="ml-1 h-4 w-4" />
-                                )}
+                                {sortField === "falsePositives" &&
+                                  (sortOrder === "asc" ? (
+                                    <IconSortAscending className="ml-1 h-4 w-4" />
+                                  ) : (
+                                    <IconSortDescending className="ml-1 h-4 w-4" />
+                                  ))}
                               </Button>
                             </TableHead>
                             <TableHead>Description</TableHead>
-                            <TableHead>Actions</TableHead>
                           </TableRow>
                         </TableHeader>
                         <TableBody>
                           {sortedVulnerabilities.map((vuln) => (
-                            <TableRow 
+                            <TableRow
                               key={vuln.cveId}
                               className="hover:bg-muted/50"
                             >
                               <TableCell>
                                 <div className="flex items-center gap-2">
                                   <IconBug className="h-4 w-4 text-muted-foreground" />
-                                  <span className="font-medium font-mono text-sm">{vuln.cveId}</span>
+                                  <span className="font-medium font-mono text-sm">
+                                    {vuln.cveId}
+                                  </span>
                                 </div>
                               </TableCell>
                               <TableCell>
-                                <Badge variant={getSeverityColor(vuln.severity as 'critical' | 'high' | 'medium' | 'low')}>
-                                  {vuln.severity.charAt(0).toUpperCase() + vuln.severity.slice(1)}
-                                </Badge>
-                              </TableCell>
-                              <TableCell>
-                                <Badge 
-                                  variant={!vuln.cvssScore ? "outline" : vuln.cvssScore >= 9.0 ? "destructive" : vuln.cvssScore >= 7.0 ? "secondary" : "outline"}
+                                <Badge
+                                  variant={getSeverityColor(
+                                    vuln.severity as
+                                      | "critical"
+                                      | "high"
+                                      | "medium"
+                                      | "low"
+                                  )}
                                 >
-                                  {vuln.cvssScore ? vuln.cvssScore.toFixed(1) : "N/A"}
+                                  {vuln.severity.charAt(0).toUpperCase() +
+                                    vuln.severity.slice(1)}
+                                </Badge>
+                              </TableCell>
+
+                              <TableCell>
+                                <div className="flex items-center gap-2">
+                                  <VulnerabilityUrlMenu
+                                    vulnerabilityId={vuln.cveId}
+                                    references={vuln.references || []}
+                                  />
+                                  {vuln.fixedVersion && (
+                                    <Badge
+                                      variant="default"
+                                      className="text-xs"
+                                    >
+                                      <IconShield className="w-3 h-3 mr-1" />
+                                      Fix: {vuln.fixedVersion}
+                                    </Badge>
+                                  )}
+                                </div>
+                              </TableCell>
+                              <TableCell>
+                                <Badge
+                                  variant={
+                                    !vuln.cvssScore
+                                      ? "outline"
+                                      : vuln.cvssScore >= 9.0
+                                      ? "destructive"
+                                      : vuln.cvssScore >= 7.0
+                                      ? "secondary"
+                                      : "outline"
+                                  }
+                                >
+                                  {vuln.cvssScore
+                                    ? vuln.cvssScore.toFixed(1)
+                                    : "N/A"}
                                 </Badge>
                               </TableCell>
                               <TableCell>
-                                <span className="font-mono text-sm">{vuln.packageName || 'N/A'}</span>
+                                <span className="font-mono text-sm">
+                                  {vuln.packageName || "N/A"}
+                                </span>
                               </TableCell>
                               <TableCell>
                                 <div className="flex gap-1 flex-wrap max-w-xs">
-                                  {vuln.affectedImages.slice(0, 3).map((image, idx) => (
-                                    <Badge 
-                                      key={`${vuln.cveId}-${image.imageName}-${idx}`} 
-                                      variant={image.isFalsePositive ? "secondary" : "outline"}
+                                  {vuln.affectedImages
+                                    .slice(0, 3)
+                                    .map((image, idx) => (
+                                      <Badge
+                                        key={`${vuln.cveId}-${image.imageName}-${idx}`}
+                                        variant={
+                                          image.isFalsePositive
+                                            ? "secondary"
+                                            : "outline"
+                                        }
+                                        className="text-xs"
+                                      >
+                                        {image.isFalsePositive && (
+                                          <IconX className="w-3 h-3 mr-1" />
+                                        )}
+                                        {image.imageName}
+                                      </Badge>
+                                    ))}
+                                  {vuln.affectedImages.length > 3 && (
+                                    <Badge
+                                      variant="outline"
                                       className="text-xs"
                                     >
-                                      {image.isFalsePositive && <IconX className="w-3 h-3 mr-1" />}
-                                      {image.imageName}
-                                    </Badge>
-                                  ))}
-                                  {vuln.affectedImages.length > 3 && (
-                                    <Badge variant="outline" className="text-xs">
                                       +{vuln.affectedImages.length - 3} more
                                     </Badge>
                                   )}
@@ -488,15 +603,25 @@ export default function LibraryHomePage() {
                               <TableCell>
                                 {vuln.falsePositiveImages.length > 0 ? (
                                   <div className="flex gap-1 flex-wrap max-w-xs">
-                                    {vuln.falsePositiveImages.slice(0, 2).map((imageName, idx) => (
-                                      <Badge key={`fp-${vuln.cveId}-${imageName}-${idx}`} variant="secondary" className="text-xs">
-                                        <IconX className="w-3 h-3 mr-1" />
-                                        {imageName}
-                                      </Badge>
-                                    ))}
+                                    {vuln.falsePositiveImages
+                                      .slice(0, 2)
+                                      .map((imageName, idx) => (
+                                        <Badge
+                                          key={`fp-${vuln.cveId}-${imageName}-${idx}`}
+                                          variant="secondary"
+                                          className="text-xs"
+                                        >
+                                          <IconX className="w-3 h-3 mr-1" />
+                                          {imageName}
+                                        </Badge>
+                                      ))}
                                     {vuln.falsePositiveImages.length > 2 && (
-                                      <Badge variant="secondary" className="text-xs">
-                                        +{vuln.falsePositiveImages.length - 2} more
+                                      <Badge
+                                        variant="secondary"
+                                        className="text-xs"
+                                      >
+                                        +{vuln.falsePositiveImages.length - 2}{" "}
+                                        more
                                       </Badge>
                                     )}
                                   </div>
@@ -509,28 +634,13 @@ export default function LibraryHomePage() {
                               </TableCell>
                               <TableCell>
                                 <div className="max-w-xs">
-                                  <p className="text-sm text-muted-foreground truncate" title={vuln.description}>
-                                    {vuln.description || 'No description available'}
-                                  </p>
-                                </div>
-                              </TableCell>
-                              <TableCell>
-                                <div className="flex items-center gap-2">
-                                  <Button
-                                    variant="ghost"
-                                    size="sm"
-                                    onClick={() => handleRowClick(vuln.cveId)}
-                                    className="text-xs"
+                                  <p
+                                    className="text-sm text-muted-foreground truncate"
+                                    title={vuln.description}
                                   >
-                                    <IconExternalLink className="w-3 h-3 mr-1" />
-                                    View
-                                  </Button>
-                                  {vuln.fixedVersion && (
-                                    <Badge variant="default" className="text-xs">
-                                      <IconShield className="w-3 h-3 mr-1" />
-                                      Fix: {vuln.fixedVersion}
-                                    </Badge>
-                                  )}
+                                    {vuln.description ||
+                                      "No description available"}
+                                  </p>
                                 </div>
                               </TableCell>
                             </TableRow>
@@ -538,10 +648,12 @@ export default function LibraryHomePage() {
                         </TableBody>
                       </Table>
                     </div>
-                    
+
                     {vulnerabilities.length === 0 && !loading && (
                       <div className="text-center py-8 text-muted-foreground">
-                        {search || severityFilter ? `No vulnerabilities found matching current filters` : "No vulnerabilities found"}
+                        {search || severityFilter
+                          ? `No vulnerabilities found matching current filters`
+                          : "No vulnerabilities found"}
                       </div>
                     )}
                   </div>
@@ -552,5 +664,5 @@ export default function LibraryHomePage() {
         </div>
       </SidebarInset>
     </SidebarProvider>
-  )
+  );
 }

--- a/src/components/vulnerability-url-menu.tsx
+++ b/src/components/vulnerability-url-menu.tsx
@@ -1,0 +1,131 @@
+"use client"
+
+import * as React from "react"
+import { IconExternalLink, IconBrandGithub, IconShield, IconDatabase } from "@tabler/icons-react"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { Button } from "@/components/ui/button"
+
+interface VulnerabilityUrlMenuProps {
+  vulnerabilityId: string
+  references: string[]
+}
+
+function getUrlIcon(url: string) {
+  if (url.includes("github.com")) return <IconBrandGithub className="h-4 w-4" />
+  if (url.includes("nvd.nist.gov")) return <IconShield className="h-4 w-4" />
+  if (url.includes("cve.mitre.org")) return <IconDatabase className="h-4 w-4" />
+  return <IconExternalLink className="h-4 w-4" />
+}
+
+function getUrlLabel(url: string): string {
+  try {
+    const urlObj = new URL(url)
+    const domain = urlObj.hostname.replace("www.", "")
+    
+    // Provide friendly names for common sources
+    if (domain === "nvd.nist.gov") return "NIST National Vulnerability Database"
+    if (domain === "github.com") {
+      if (url.includes("/advisories/")) return "GitHub Security Advisory"
+      return "GitHub"
+    }
+    if (domain === "cve.mitre.org") return "MITRE CVE Database"
+    if (domain === "security.snyk.io") return "Snyk Vulnerability Database"
+    if (domain === "access.redhat.com") return "Red Hat Security"
+    if (domain === "ubuntu.com") return "Ubuntu Security"
+    if (domain === "debian.org") return "Debian Security"
+    
+    // Default to domain name
+    return domain
+  } catch {
+    return "External Link"
+  }
+}
+
+function processVulnerabilityUrls(vulnerabilityId: string, references: string[]): string[] {
+  const urls = [...references]
+  
+  // Add smart URL detection for GHSA vulnerabilities
+  if (vulnerabilityId.startsWith("GHSA-")) {
+    const ghsaUrl = `https://github.com/advisories/${vulnerabilityId}`
+    // Only add if not already in the list
+    if (!urls.some(url => url.includes(vulnerabilityId))) {
+      urls.unshift(ghsaUrl) // Add at the beginning as it's likely the most relevant
+    }
+  }
+  
+  // Add CVE link if it's a CVE and not already present
+  if (vulnerabilityId.startsWith("CVE-")) {
+    const nistUrl = `https://nvd.nist.gov/vuln/detail/${vulnerabilityId}`
+    const mitreUrl = `https://cve.mitre.org/cgi-bin/cvename.cgi?name=${vulnerabilityId}`
+    
+    if (!urls.some(url => url.includes("nvd.nist.gov") && url.includes(vulnerabilityId))) {
+      urls.push(nistUrl)
+    }
+    if (!urls.some(url => url.includes("cve.mitre.org") && url.includes(vulnerabilityId))) {
+      urls.push(mitreUrl)
+    }
+  }
+  
+  // Remove duplicates while preserving order
+  return Array.from(new Set(urls))
+}
+
+export function VulnerabilityUrlMenu({ vulnerabilityId, references }: VulnerabilityUrlMenuProps) {
+  const processedUrls = processVulnerabilityUrls(vulnerabilityId, references)
+  
+  // If no URLs available, don't render anything
+  if (processedUrls.length === 0) {
+    return null
+  }
+  
+  // If only one URL, render a simple link button
+  if (processedUrls.length === 1) {
+    return (
+      <Button variant="ghost" size="sm" asChild>
+        <a
+          href={processedUrls[0]}
+          target="_blank"
+          rel="noopener noreferrer"
+          title="View vulnerability details"
+        >
+          <IconExternalLink className="h-4 w-4" />
+        </a>
+      </Button>
+    )
+  }
+  
+  // Multiple URLs - show dropdown menu
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="sm" title="View vulnerability details">
+          <IconExternalLink className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-64">
+        <DropdownMenuLabel>View Vulnerability Details</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {processedUrls.map((url, index) => (
+          <DropdownMenuItem key={index} asChild>
+            <a
+              href={url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-2 cursor-pointer"
+            >
+              {getUrlIcon(url)}
+              <span className="flex-1 truncate">{getUrlLabel(url)}</span>
+            </a>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}


### PR DESCRIPTION
## Summary
- Fixes incorrect routing of GHSA vulnerabilities to NVD instead of GitHub Advisories
- Adds context menu for vulnerabilities with multiple reference URLs
- Implements intelligent URL detection based on vulnerability ID patterns

## Problem
As reported in #21, when viewing vulnerability details for GitHub Security Advisories (GHSA), the "View" button was incorrectly routing to `nvd.nist.gov` instead of the appropriate GitHub advisory page. This happened because the code was simply using the first URL from the references array without considering the vulnerability type.

## Solution
Created a new `VulnerabilityUrlMenu` component that:
1. **Single URL**: Shows a simple link button when only one reference is available
2. **Multiple URLs**: Displays a dropdown menu with all available options
3. **Smart Detection**: Automatically adds appropriate URLs based on vulnerability ID:
   - GHSA IDs → GitHub Advisory URLs
   - CVE IDs → NVD and MITRE database URLs
4. **User-Friendly Labels**: Shows recognizable names for common vulnerability databases

## Changes
- ✅ New reusable `VulnerabilityUrlMenu` component
- ✅ Updated Library main page (`/library`)
- ✅ Updated Library details page (`/library/[name]`)  
- ✅ Updated Scan details page (`/image/[name]/scan/[scanId]`)
- ✅ Automatic URL generation for GHSA and CVE vulnerabilities
- ✅ Deduplication of reference URLs
- ✅ Visual icons for different vulnerability databases

## Testing
- Vulnerabilities with GHSA IDs now correctly show GitHub advisory links
- CVE vulnerabilities ensure NVD and MITRE links are available
- Single reference URLs display as before (simple button)
- Multiple references show dropdown with all options

## Screenshots
The new context menu provides clear options when multiple vulnerability references are available, while maintaining the simple interface for single references.

Fixes #21