### PR TITLE
Add HEALTHCHECK to Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,4 +73,8 @@ ENV DATABASE_URL="file:./app.db"
 USER root
 EXPOSE 3000
 
+# Health check using the /api/health endpoint
+HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
+  CMD curl -f http://localhost:3000/api/health || exit 1
+
 CMD ["sh", "-c", "node scripts/init-database.js && node server.js"]

--- a/README.md
+++ b/README.md
@@ -116,6 +116,25 @@ When `HEALTH_CHECK_ENABLED=true` (default), Harbor Guard provides monitoring end
 - **`HEAD /api/health`** - Lightweight health check (returns HTTP status only)
 - **`HEAD /api/ready`** - Lightweight readiness check (returns HTTP status only)
 
+#### Docker Health Check
+
+The Harbor Guard Docker image includes a built-in HEALTHCHECK instruction that automatically monitors container health:
+
+- **Interval**: 30 seconds between health checks
+- **Timeout**: 10 seconds for each health check request
+- **Start Period**: 40 seconds grace period during container startup
+- **Retries**: 3 consecutive failures before marking container as unhealthy
+
+The health check uses the `/api/health` endpoint to verify:
+- Application is responding to HTTP requests
+- Database connectivity is working
+- Critical services are operational
+
+Docker and orchestration platforms (like Docker Compose, Kubernetes, etc.) will automatically use this health check to:
+- Monitor container health status
+- Restart unhealthy containers (if configured)
+- Route traffic only to healthy instances in load-balanced setups
+
 ## Screenshots
 
 <div align="center">


### PR DESCRIPTION
## Summary
- Adds Docker HEALTHCHECK instruction to monitor container health
- Utilizes existing `/api/health` endpoint for health verification
- Documents health check behavior in README

## Implementation Details
The implementation is straightforward as suggested in the issue:
- Added HEALTHCHECK instruction to Dockerfile with production-ready settings:
  - 30s interval between checks
  - 10s timeout per check
  - 40s startup grace period
  - 3 retries before marking unhealthy
- Uses `curl` (already installed) to check `/api/health` endpoint
- No code changes required - purely configuration

## Testing
The health check will automatically:
- Report container health status to Docker daemon
- Enable automatic restarts for unhealthy containers (when configured)
- Integrate with orchestration platforms (Docker Swarm, Kubernetes)

Closes #9