### PR TITLE
Fix PostgreSQL connection failure due to duplicate fs declaration

### DIFF
--- a/scripts/init-database.js
+++ b/scripts/init-database.js
@@ -75,7 +75,6 @@ async function testPostgreSQLConnection(url) {
     
     // Create a simple test SQL file
     const testSql = 'SELECT 1;';
-    const fs = require('fs');
     const testFile = '/tmp/test-connection.sql';
     fs.writeFileSync(testFile, testSql);
     


### PR DESCRIPTION
## Summary
Fixes a critical bug preventing PostgreSQL connections from working properly.

## Root Cause Analysis

### The Issue
The `init-database.js` script contained a duplicate `fs` constant declaration on line 78 within the `testPostgreSQLConnection` function. Since `fs` was already imported at the module level (line 3), this redeclaration caused:
```
ReferenceError: Cannot access 'fs' before initialization
```

### Why PR #26 Didn't Suffice
PR #26 successfully implemented PostgreSQL support with sound connection logic. However, during subsequent refactoring to improve the connection test mechanism, a duplicate `const fs = require('fs')` was inadvertently added inside the `testPostgreSQLConnection` function. 

This scoping issue prevented the PostgreSQL connection test from executing, causing all PostgreSQL connections to fail and fall back to SQLite.

## Resolution
Removed the duplicate `fs` declaration from line 78, allowing the function to use the module-level `fs` import.

## Testing
✅ PostgreSQL container starts successfully
✅ Database initialization completes without errors  
✅ Application connects to PostgreSQL
✅ Health check reports healthy database connection
✅ Database migrations apply correctly

### Test Configuration
```bash
docker run -d \
  --name harborguard-postgres \
  -e POSTGRES_USER=harborguard \
  -e POSTGRES_PASSWORD=harborguard123 \
  -e POSTGRES_DB=harborguard \
  -p 5432:5432 \
  postgres:16-alpine

DATABASE_URL="postgresql://harborguard:harborguard123@localhost:5432/harborguard?sslmode=disable" npm run db:init
```

Fixes #30