### PR TITLE
Fix database authentication mismatch for bundled PostgreSQL

### DIFF
--- a/scripts/init-database-with-fallback.js
+++ b/scripts/init-database-with-fallback.js
@@ -60,6 +60,9 @@ async function startBundledPostgreSQL() {
     console.log('[DB] Starting bundled PostgreSQL...');
     
     const pgData = process.env.PGDATA || '/var/lib/postgresql/data';
+    const pgUser = process.env.POSTGRES_USER || 'harborguard';
+    const pgPassword = process.env.POSTGRES_PASSWORD || 'harborguard';
+    const pgDatabase = process.env.POSTGRES_DB || 'harborguard';
     
     // Check if PostgreSQL is already initialized
     const fs = require('fs');
@@ -81,11 +84,11 @@ async function startBundledPostgreSQL() {
       await execAsync('sleep 3'); // Wait for PostgreSQL to start
     }
     
-    // Create user and database if needed
-    await execAsync('su - postgres -c "psql -tc \\"SELECT 1 FROM pg_user WHERE usename = \'harborguard\'\\" | grep -q 1 || psql -c \\"CREATE USER harborguard WITH PASSWORD \'harborguard\';\\"" || true');
-    await execAsync('su - postgres -c "psql -tc \\"SELECT 1 FROM pg_database WHERE datname = \'harborguard\'\\" | grep -q 1 || psql -c \\"CREATE DATABASE harborguard OWNER harborguard;\\"" || true');
+    // Create user and database if needed - using environment variables
+    await execAsync(`su - postgres -c "psql -tc \\"SELECT 1 FROM pg_user WHERE usename = '${pgUser}'\\" | grep -q 1 || psql -c \\"CREATE USER ${pgUser} WITH PASSWORD '${pgPassword}';\\"" || true`);
+    await execAsync(`su - postgres -c "psql -tc \\"SELECT 1 FROM pg_database WHERE datname = '${pgDatabase}'\\" | grep -q 1 || psql -c \\"CREATE DATABASE ${pgDatabase} OWNER ${pgUser};\\"" || true`);
     
-    return 'postgresql://harborguard:harborguard@localhost:5432/harborguard?sslmode=disable';
+    return `postgresql://${pgUser}:${pgPassword}@localhost:5432/${pgDatabase}?sslmode=disable`;
   } catch (error) {
     console.error(`[DB] Failed to start bundled PostgreSQL: ${error.message}`);
     throw error;

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -5,11 +5,9 @@ set -e
 if [ -z "$DATABASE_URL" ]; then
   echo "No external DATABASE_URL provided, using bundled PostgreSQL"
   USE_BUNDLED_PG=true
-  # Generate secure random password if not provided (alphanumeric only for URL safety)
-  if [ -z "$POSTGRES_PASSWORD" ]; then
-    export POSTGRES_PASSWORD=$(openssl rand -base64 32 | tr -d "=+/")
-    echo "Generated PostgreSQL password for bundled database"
-  fi
+  # Use a fixed password for bundled PostgreSQL for simplicity
+  # In production, this should be generated or provided via environment
+  export POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-harborguard}
   # Set default values if not provided
   export POSTGRES_USER=${POSTGRES_USER:-harborguard}
   export POSTGRES_DB=${POSTGRES_DB:-harborguard}


### PR DESCRIPTION
## Summary
Fixes authentication failures when using bundled PostgreSQL database due to credential mismatches between initialization scripts.

## Problem
The application was failing to start with the following error:
```
Error: P1000: Authentication failed against database server, the provided database credentials for `harborguard` are not valid.
```

This occurred when:
1. Container starts and creates bundled PostgreSQL with random password
2. Container restarts and PostgreSQL data persists
3. New container generates different random password
4. Authentication fails due to password mismatch

## Root Cause Analysis
- `start.sh` was generating a random password on each container start using `openssl rand`
- `init-database-with-fallback.js` was using hardcoded credentials (`harborguard:harborguard`)
- When PostgreSQL data persisted between container restarts, the passwords would not match

## Solution
Updated both scripts to use consistent credentials via environment variables:

### Changes in `init-database-with-fallback.js`:
- Read PostgreSQL credentials from environment variables
- Use `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB`
- Default to `harborguard` for all values if not provided

### Changes in `start.sh`:
- Replaced random password generation with fixed default
- Use environment variable `POSTGRES_PASSWORD` or default to `harborguard`
- Ensures consistency across container restarts

## Testing
- [x] Built Docker image with changes
- [x] Started container with bundled PostgreSQL
- [x] Verified successful database connection
- [x] Restarted container to ensure persistence works
- [x] Confirmed authentication succeeds on restart

## Impact
- Fixes critical startup failures in production environments
- Ensures database persistence works correctly
- No breaking changes for existing deployments

## Related Issues
Addresses authentication errors reported in container logs