### PR TITLE
feat: Add comprehensive vulnerability details modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "harborguard",
-  "version": "0.1b",
+  "version": "0.2b",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "harborguard",
-      "version": "0.1b",
+      "version": "0.2b",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
@@ -22,6 +22,7 @@
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-progress": "^1.1.7",
+        "@radix-ui/react-scroll-area": "^1.2.10",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.3",
@@ -1935,6 +1936,67 @@
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-use-callback-ref": "1.1.1",
         "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.10.tgz",
+      "integrity": "sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-progress": "^1.1.7",
+    "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",

--- a/src/app/api/scans/route.ts
+++ b/src/app/api/scans/route.ts
@@ -21,7 +21,7 @@ export async function GET(request: NextRequest) {
       where.imageId = imageId
     }
     
-    // Selective field loading - exclude large JSON fields by default
+    // Selective field loading - always include metadata for vulnerability counts
     const selectFields = includeReports ? undefined : {
       id: true,
       requestId: true,
@@ -35,7 +35,7 @@ export async function GET(request: NextRequest) {
       createdAt: true,
       updatedAt: true,
       source: true,
-      // Exclude large JSON fields: metadata
+      metadata: true, // Include metadata to calculate vulnerability counts
       image: {
         select: {
           id: true,
@@ -73,21 +73,138 @@ export async function GET(request: NextRequest) {
       prisma.scan.count({ where })
     ])
     
+    // Helper function to calculate vulnerability counts from metadata
+    const calculateVulnerabilityCounts = (scan: any) => {
+      const counts = { total: 0, critical: 0, high: 0, medium: 0, low: 0 };
+      
+      // Process if we have metadata
+      if (scan.metadata) {
+        const metadata = scan.metadata as any;
+        const scanResults = metadata?.scanResults;
+        
+        // Track unique CVEs to avoid double-counting
+        const cveTracker = new Map<string, string>(); // CVE ID -> highest severity
+        
+        // Helper function to get severity priority
+        const getSeverityPriority = (severity: string) => {
+          switch (severity.toUpperCase()) {
+            case 'CRITICAL': return 4;
+            case 'HIGH': return 3;
+            case 'MEDIUM': return 2;
+            case 'LOW':
+            case 'NEGLIGIBLE':
+            case 'INFO': return 1;
+            default: return 0;
+          }
+        };
+        
+        // Process Trivy results
+        if (scanResults?.trivy?.Results) {
+          for (const result of scanResults.trivy.Results) {
+            if (result.Vulnerabilities && Array.isArray(result.Vulnerabilities)) {
+              for (const vuln of result.Vulnerabilities) {
+                const cveId = vuln.VulnerabilityID || vuln.PkgID || `trivy-${vuln.PkgName}-${vuln.InstalledVersion}`;
+                const severity = (vuln.Severity || 'UNKNOWN').toUpperCase();
+                
+                const existingSeverity = cveTracker.get(cveId);
+                if (!existingSeverity || getSeverityPriority(severity) > getSeverityPriority(existingSeverity)) {
+                  cveTracker.set(cveId, severity);
+                }
+              }
+            }
+          }
+        }
+        
+        // Process Grype results
+        if (scanResults?.grype?.matches) {
+          for (const match of scanResults.grype.matches) {
+            const cveId = match.vulnerability?.id || `grype-${match.artifact?.name}-${match.artifact?.version}`;
+            const severity = (match.vulnerability?.severity || 'UNKNOWN').toUpperCase();
+            
+            const existingSeverity = cveTracker.get(cveId);
+            if (!existingSeverity || getSeverityPriority(severity) > getSeverityPriority(existingSeverity)) {
+              cveTracker.set(cveId, severity);
+            }
+          }
+        }
+        
+        // Count vulnerabilities using highest severity
+        for (const [cveId, severity] of cveTracker.entries()) {
+          switch (severity) {
+            case 'CRITICAL':
+              counts.critical++;
+              break;
+            case 'HIGH':
+              counts.high++;
+              break;
+            case 'MEDIUM':
+              counts.medium++;
+              break;
+            case 'LOW':
+            case 'NEGLIGIBLE':
+            case 'INFO':
+              counts.low++;
+              break;
+          }
+          counts.total++;
+        }
+      }
+      
+      return counts;
+    };
+    
+    // Helper function to calculate Dockle compliance grade
+    const calculateDockleGrade = (scan: any) => {
+      if (scan.metadata) {
+        const metadata = scan.metadata as any;
+        const dockleResults = metadata?.scanResults?.dockle;
+        
+        if (dockleResults?.summary) {
+          const summary = dockleResults.summary;
+          // If grade exists, use it
+          if (summary.grade) {
+            return summary.grade;
+          }
+          // Calculate grade based on fatal and warn counts
+          const fatal = summary.fatal || 0;
+          const warn = summary.warn || 0;
+          const info = summary.info || 0;
+          
+          if (fatal > 0) {
+            return 'F';
+          } else if (warn > 5) {
+            return 'D';
+          } else if (warn > 2) {
+            return 'C';
+          } else if (warn > 0 || info > 5) {
+            return 'B';
+          } else {
+            return 'A';
+          }
+        }
+      }
+      return null;
+    };
+    
     // Convert Prisma data - handle different query structures
     const scansData = scans.map((scan: any) => {
-      if (selectFields) {
-        // When using select, convert manually
-        return {
-          ...scan,
-          image: scan.image ? {
-            ...scan.image,
-            sizeBytes: scan.image.sizeBytes?.toString() || null
-          } : undefined
-        }
-      } else {
-        // When using include, use the helper function
-        return prismaToScanWithImage(scan)
-      }
+      const baseData = selectFields ? {
+        ...scan,
+        image: scan.image ? {
+          ...scan.image,
+          sizeBytes: scan.image.sizeBytes?.toString() || null
+        } : undefined
+      } : prismaToScanWithImage(scan);
+      
+      // Add vulnerability counts and Dockle grade if metadata is available
+      const vulnerabilityCount = calculateVulnerabilityCounts(scan);
+      const dockleGrade = calculateDockleGrade(scan);
+      
+      return {
+        ...baseData,
+        vulnerabilityCount,
+        dockleGrade
+      };
     });
     
     return NextResponse.json({

--- a/src/app/image/[name]/page.tsx
+++ b/src/app/image/[name]/page.tsx
@@ -340,7 +340,7 @@ export default function ImageDetailsPage() {
           misconfigs: 0, // TODO: Extract from dockle data
           secrets: 0, // TODO: Extract from trivy data
           compliance: {
-            dockle: scan.complianceScore?.dockle?.grade || "N/A",
+            dockle: scan.dockleGrade || scan.complianceScore?.dockle?.grade || "N/A",
           },
           dbVersion: "1.0", // TODO: Get from scan metadata
           scanEngine: "Multi-tool", // TODO: Get from scannerVersions

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -19,6 +19,7 @@ import { AppSidebar } from "@/components/app-sidebar";
 import { SiteHeader } from "@/components/site-header";
 import { Button } from "@/components/ui/button";
 import { VulnerabilityUrlMenu } from "@/components/vulnerability-url-menu";
+import { VulnerabilityDetailsModal } from "@/components/vulnerability-details-modal";
 import {
   Card,
   CardContent,
@@ -85,6 +86,10 @@ export default function LibraryHomePage() {
     offset: 0,
     hasMore: false,
   });
+  
+  // Modal state
+  const [selectedVulnerability, setSelectedVulnerability] = React.useState<VulnerabilityData | null>(null);
+  const [isModalOpen, setIsModalOpen] = React.useState(false);
 
   // Fetch vulnerabilities from API
   const fetchVulnerabilities = React.useCallback(async () => {
@@ -196,6 +201,12 @@ export default function LibraryHomePage() {
     { label: "Dashboard", href: "/" },
     { label: "Vulnerability Library" },
   ];
+  
+  // Handle vulnerability click
+  const handleVulnerabilityClick = (vuln: VulnerabilityData) => {
+    setSelectedVulnerability(vuln);
+    setIsModalOpen(true);
+  };
 
   // Calculate overall statistics
   const stats = React.useMemo(() => {
@@ -478,7 +489,8 @@ export default function LibraryHomePage() {
                       {sortedVulnerabilities.map((vuln) => (
                         <TableRow
                           key={vuln.cveId}
-                          className="hover:bg-muted/50"
+                          className="hover:bg-muted/50 cursor-pointer"
+                          onClick={() => handleVulnerabilityClick(vuln)}
                         >
                           <TableCell>
                             <div className="flex items-center gap-2">
@@ -503,7 +515,7 @@ export default function LibraryHomePage() {
                             </Badge>
                           </TableCell>
 
-                          <TableCell>
+                          <TableCell onClick={(e) => e.stopPropagation()}>
                             <div className="flex items-center gap-2">
                               <VulnerabilityUrlMenu
                                 vulnerabilityId={vuln.cveId}
@@ -625,6 +637,16 @@ export default function LibraryHomePage() {
           </Card>
         </div>
       </div>
+      
+      {/* Vulnerability Details Modal */}
+      <VulnerabilityDetailsModal
+        vulnerability={selectedVulnerability}
+        isOpen={isModalOpen}
+        onClose={() => {
+          setIsModalOpen(false);
+          setSelectedVulnerability(null);
+        }}
+      />
     </div>
   );
 }

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import * as React from "react"
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
+
+import { cn } from "components/lib/utils"
+
+function ScrollArea({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+  return (
+    <ScrollAreaPrimitive.Root
+      data-slot="scroll-area"
+      className={cn("relative", className)}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Viewport
+        data-slot="scroll-area-viewport"
+        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+      >
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollBar />
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  )
+}
+
+function ScrollBar({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>) {
+  return (
+    <ScrollAreaPrimitive.ScrollAreaScrollbar
+      data-slot="scroll-area-scrollbar"
+      orientation={orientation}
+      className={cn(
+        "flex touch-none p-px transition-colors select-none",
+        orientation === "vertical" &&
+          "h-full w-2.5 border-l border-l-transparent",
+        orientation === "horizontal" &&
+          "h-2.5 flex-col border-t border-t-transparent",
+        className
+      )}
+      {...props}
+    >
+      <ScrollAreaPrimitive.ScrollAreaThumb
+        data-slot="scroll-area-thumb"
+        className="bg-border relative flex-1 rounded-full"
+      />
+    </ScrollAreaPrimitive.ScrollAreaScrollbar>
+  )
+}
+
+export { ScrollArea, ScrollBar }

--- a/src/components/vulnerability-details-modal.tsx
+++ b/src/components/vulnerability-details-modal.tsx
@@ -1,0 +1,395 @@
+"use client";
+
+import * as React from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { VulnerabilityUrlMenu } from "@/components/vulnerability-url-menu";
+import {
+  IconBug,
+  IconShield,
+  IconAlertTriangle,
+  IconPackage,
+  IconExternalLink,
+  IconCalendar,
+  IconHash,
+  IconInfoCircle,
+  IconX,
+  IconCheck,
+  IconCopy,
+} from "@tabler/icons-react";
+import { toast } from "sonner";
+
+interface VulnerabilityDetailsModalProps {
+  vulnerability: {
+    cveId: string;
+    severity: string;
+    description?: string;
+    cvssScore?: number;
+    cvssVector?: string;
+    packageName?: string;
+    installedVersion?: string;
+    fixedVersion?: string;
+    publishedDate?: string;
+    lastModifiedDate?: string;
+    references?: string[];
+    affectedImages: Array<{
+      imageName: string;
+      imageId: string;
+      isFalsePositive: boolean;
+    }>;
+    falsePositiveImages: string[];
+    exploitAvailable?: boolean;
+    epssScore?: number;
+    cweIds?: string[];
+  } | null;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+function getSeverityColor(severity: string): "destructive" | "secondary" | "default" | "outline" {
+  switch (severity?.toLowerCase()) {
+    case "critical":
+      return "destructive";
+    case "high":
+      return "secondary";
+    case "medium":
+      return "default";
+    case "low":
+    default:
+      return "outline";
+  }
+}
+
+export function VulnerabilityDetailsModal({
+  vulnerability,
+  isOpen,
+  onClose,
+}: VulnerabilityDetailsModalProps) {
+  const copyToClipboard = (text: string) => {
+    navigator.clipboard.writeText(text);
+    toast.success("Copied to clipboard");
+  };
+
+  if (!vulnerability) return null;
+
+  const trulyAffectedImages = vulnerability.affectedImages.filter(
+    (img) => !img.isFalsePositive
+  );
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="max-w-4xl max-h-[90vh] overflow-hidden">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-3">
+            <IconBug className="h-5 w-5 text-muted-foreground" />
+            <span className="font-mono">{vulnerability.cveId}</span>
+            <Badge variant={getSeverityColor(vulnerability.severity)}>
+              {vulnerability.severity.toUpperCase()}
+            </Badge>
+            {vulnerability.cvssScore && (
+              <Badge
+                variant={
+                  vulnerability.cvssScore >= 9.0
+                    ? "destructive"
+                    : vulnerability.cvssScore >= 7.0
+                    ? "secondary"
+                    : "outline"
+                }
+              >
+                CVSS {vulnerability.cvssScore.toFixed(1)}
+              </Badge>
+            )}
+          </DialogTitle>
+          <DialogDescription>
+            Comprehensive vulnerability information and affected resources
+          </DialogDescription>
+        </DialogHeader>
+
+        <ScrollArea className="h-[calc(90vh-120px)] pr-4">
+          <div className="space-y-6">
+            {/* Description Section */}
+            {vulnerability.description && (
+              <div className="space-y-2">
+                <h3 className="text-sm font-semibold flex items-center gap-2">
+                  <IconInfoCircle className="h-4 w-4" />
+                  Description
+                </h3>
+                <p className="text-sm text-muted-foreground leading-relaxed">
+                  {vulnerability.description}
+                </p>
+              </div>
+            )}
+
+            {/* Package Information */}
+            <div className="space-y-2">
+              <h3 className="text-sm font-semibold flex items-center gap-2">
+                <IconPackage className="h-4 w-4" />
+                Package Information
+              </h3>
+              <div className="grid grid-cols-2 gap-4 text-sm">
+                <div>
+                  <span className="text-muted-foreground">Package: </span>
+                  <span className="font-mono">
+                    {vulnerability.packageName || "N/A"}
+                  </span>
+                </div>
+                {vulnerability.installedVersion && (
+                  <div>
+                    <span className="text-muted-foreground">Installed Version: </span>
+                    <span className="font-mono">
+                      {vulnerability.installedVersion}
+                    </span>
+                  </div>
+                )}
+                {vulnerability.fixedVersion && (
+                  <div>
+                    <span className="text-muted-foreground">Fixed Version: </span>
+                    <Badge variant="default" className="ml-2">
+                      <IconShield className="w-3 h-3 mr-1" />
+                      {vulnerability.fixedVersion}
+                    </Badge>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* Risk Assessment */}
+            <div className="space-y-2">
+              <h3 className="text-sm font-semibold flex items-center gap-2">
+                <IconAlertTriangle className="h-4 w-4" />
+                Risk Assessment
+              </h3>
+              <div className="grid grid-cols-2 gap-4 text-sm">
+                {vulnerability.cvssVector && (
+                  <div className="col-span-2">
+                    <span className="text-muted-foreground">CVSS Vector: </span>
+                    <code className="font-mono text-xs bg-muted px-2 py-1 rounded">
+                      {vulnerability.cvssVector}
+                    </code>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-6 w-6 ml-2"
+                      onClick={() => copyToClipboard(vulnerability.cvssVector!)}
+                    >
+                      <IconCopy className="h-3 w-3" />
+                    </Button>
+                  </div>
+                )}
+                {vulnerability.exploitAvailable !== undefined && (
+                  <div>
+                    <span className="text-muted-foreground">Exploit Available: </span>
+                    {vulnerability.exploitAvailable ? (
+                      <Badge variant="destructive" className="ml-2">
+                        <IconAlertTriangle className="w-3 h-3 mr-1" />
+                        Yes
+                      </Badge>
+                    ) : (
+                      <Badge variant="outline" className="ml-2">No</Badge>
+                    )}
+                  </div>
+                )}
+                {vulnerability.epssScore !== undefined && (
+                  <div>
+                    <span className="text-muted-foreground">EPSS Score: </span>
+                    <Badge variant="outline" className="ml-2">
+                      {(vulnerability.epssScore * 100).toFixed(2)}%
+                    </Badge>
+                  </div>
+                )}
+                {vulnerability.cweIds && vulnerability.cweIds.length > 0 && (
+                  <div className="col-span-2">
+                    <span className="text-muted-foreground">CWE IDs: </span>
+                    {vulnerability.cweIds.map((cwe) => (
+                      <Badge key={cwe} variant="outline" className="ml-1">
+                        {cwe}
+                      </Badge>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* Timeline */}
+            {(vulnerability.publishedDate || vulnerability.lastModifiedDate) && (
+              <div className="space-y-2">
+                <h3 className="text-sm font-semibold flex items-center gap-2">
+                  <IconCalendar className="h-4 w-4" />
+                  Timeline
+                </h3>
+                <div className="grid grid-cols-2 gap-4 text-sm">
+                  {vulnerability.publishedDate && (
+                    <div>
+                      <span className="text-muted-foreground">Published: </span>
+                      <span>
+                        {new Date(vulnerability.publishedDate).toLocaleDateString()}
+                      </span>
+                    </div>
+                  )}
+                  {vulnerability.lastModifiedDate && (
+                    <div>
+                      <span className="text-muted-foreground">Last Modified: </span>
+                      <span>
+                        {new Date(vulnerability.lastModifiedDate).toLocaleDateString()}
+                      </span>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* Affected Images */}
+            <div className="space-y-2">
+              <h3 className="text-sm font-semibold flex items-center gap-2">
+                <IconHash className="h-4 w-4" />
+                Affected Images ({trulyAffectedImages.length})
+              </h3>
+              <div className="space-y-2 max-h-40 overflow-y-auto">
+                {trulyAffectedImages.length > 0 ? (
+                  trulyAffectedImages.map((image) => (
+                    <div
+                      key={`${image.imageId}-${image.imageName}`}
+                      className="flex items-center justify-between p-2 rounded-md bg-muted/50"
+                    >
+                      <span className="font-mono text-sm">{image.imageName}</span>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => {
+                          window.open(`/image/${encodeURIComponent(image.imageName)}`, "_blank");
+                        }}
+                      >
+                        View Details
+                        <IconExternalLink className="ml-1 h-3 w-3" />
+                      </Button>
+                    </div>
+                  ))
+                ) : (
+                  <p className="text-sm text-muted-foreground">
+                    No images affected (all marked as false positives)
+                  </p>
+                )}
+              </div>
+            </div>
+
+            {/* False Positives */}
+            {vulnerability.falsePositiveImages.length > 0 && (
+              <div className="space-y-2">
+                <h3 className="text-sm font-semibold flex items-center gap-2">
+                  <IconX className="h-4 w-4" />
+                  False Positives ({vulnerability.falsePositiveImages.length})
+                </h3>
+                <div className="flex gap-2 flex-wrap">
+                  {vulnerability.falsePositiveImages.map((imageName) => (
+                    <Badge
+                      key={imageName}
+                      variant="secondary"
+                      className="text-xs"
+                    >
+                      <IconCheck className="w-3 h-3 mr-1" />
+                      {imageName}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <Separator />
+
+            {/* References */}
+            {vulnerability.references && vulnerability.references.length > 0 && (
+              <div className="space-y-3">
+                <h3 className="text-sm font-semibold flex items-center gap-2">
+                  <IconExternalLink className="h-4 w-4" />
+                  References & Resources ({vulnerability.references.length})
+                </h3>
+                <div className="space-y-2">
+                  {vulnerability.references.map((ref, index) => {
+                    // Extract domain name for display
+                    let displayName = ref;
+                    try {
+                      const url = new URL(ref);
+                      displayName = url.hostname.replace('www.', '');
+                      
+                      // Add path context for certain domains
+                      if (url.pathname && url.pathname !== '/') {
+                        const pathParts = url.pathname.split('/').filter(p => p);
+                        if (pathParts.length > 0) {
+                          // For GitHub, show repo/issue info
+                          if (displayName.includes('github.com') && pathParts.length >= 2) {
+                            displayName = `GitHub - ${pathParts[0]}/${pathParts[1]}`;
+                            if (pathParts[2] === 'issues' && pathParts[3]) {
+                              displayName += ` #${pathParts[3]}`;
+                            }
+                          }
+                          // For NVD, show CVE ID
+                          else if (displayName.includes('nvd.nist.gov')) {
+                            displayName = 'NVD - National Vulnerability Database';
+                          }
+                          // For Mitre, show CVE database
+                          else if (displayName.includes('cve.mitre.org')) {
+                            displayName = 'MITRE CVE Dictionary';
+                          }
+                          // For Red Hat
+                          else if (displayName.includes('redhat.com')) {
+                            displayName = 'Red Hat Security Advisory';
+                          }
+                        }
+                      }
+                    } catch (e) {
+                      // If URL parsing fails, use the original reference
+                    }
+                    
+                    return (
+                      <div key={index} className="flex items-center gap-2 group">
+                        <IconExternalLink className="h-3 w-3 text-muted-foreground flex-shrink-0" />
+                        <a
+                          href={ref}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-sm text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 hover:underline truncate max-w-full"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          {displayName}
+                        </a>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            copyToClipboard(ref);
+                          }}
+                        >
+                          <IconCopy className="h-3 w-3" />
+                        </Button>
+                      </div>
+                    );
+                  })}
+                </div>
+                <div className="pt-2 border-t">
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <VulnerabilityUrlMenu
+                      vulnerabilityId={vulnerability.cveId}
+                      references={vulnerability.references}
+                    />
+                    <span>Quick access to all vulnerability databases</span>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- Added a new VulnerabilityDetailsModal component that displays comprehensive vulnerability information
- Integrated modal into vulnerability library and scan results pages
- Fixed vulnerability aggregation to properly combine results from both Trivy and Grype scanners

## Changes

### New Features
- **Vulnerability Details Modal**: Created a comprehensive modal component that displays:
  - CVE ID, severity, and CVSS scores
  - Detailed vulnerability descriptions
  - Package information with installed and fixed versions
  - Risk assessment metrics (CVSS vector, exploit availability, EPSS score)
  - Timeline showing published and last modified dates
  - List of affected images with navigation links
  - False positive tracking
  - Clickable hyperlinks for all references and external resources

### Integration Points
- **Vulnerability Library Page** (): 
  - Table rows are now clickable to open the modal
  - Added hover effects and cursor styling
  - Prevented action menu clicks from triggering row selection

- **Scan Results Page** ():
  - Made Trivy and Grype vulnerability table rows clickable
  - Transforms scanner-specific data formats to modal format
  - Handles differences between Trivy and Grype data structures

### Bug Fixes
- Fixed Dockle grade display showing 'N/A' by checking both `dockleGrade` and `complianceScore.dockle.grade` paths
- Fixed vulnerability aggregation to properly combine Trivy and Grype results using highest severity when scanners disagree
- Added vulnerability count calculation to `/api/scans` endpoint for proper display in image details

### Dependencies
- Added scroll-area component from shadcn/ui for better modal content scrolling

## Testing
- Tested modal opening from vulnerability library table
- Verified modal displays correctly with Trivy and Grype data
- Confirmed all references display as clickable links
- Validated Dockle grades now display correctly
- Verified combined vulnerability counts from both scanners