### PR TITLE
feat: Add clickable navigation for library badges

### DIFF
--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -551,7 +551,7 @@ export default function LibraryHomePage() {
                               {vuln.packageName || "N/A"}
                             </span>
                           </TableCell>
-                          <TableCell>
+                          <TableCell onClick={(e) => e.stopPropagation()}>
                             <div className="flex gap-1 flex-wrap max-w-xs">
                               {vuln.affectedImages
                                 .slice(0, 3)
@@ -563,7 +563,11 @@ export default function LibraryHomePage() {
                                         ? "secondary"
                                         : "outline"
                                     }
-                                    className="text-xs"
+                                    className="text-xs cursor-pointer hover:opacity-80"
+                                    onClick={() => {
+                                      const imageName = image.imageName.split(':')[0];
+                                      router.push(`/image/${encodeURIComponent(imageName)}`);
+                                    }}
                                   >
                                     {image.isFalsePositive && (
                                       <IconX className="w-3 h-3 mr-1" />
@@ -578,7 +582,7 @@ export default function LibraryHomePage() {
                               )}
                             </div>
                           </TableCell>
-                          <TableCell>
+                          <TableCell onClick={(e) => e.stopPropagation()}>
                             {vuln.falsePositiveImages.length > 0 ? (
                               <div className="flex gap-1 flex-wrap max-w-xs">
                                 {vuln.falsePositiveImages
@@ -587,7 +591,11 @@ export default function LibraryHomePage() {
                                     <Badge
                                       key={`fp-${vuln.cveId}-${imageName}-${idx}`}
                                       variant="secondary"
-                                      className="text-xs"
+                                      className="text-xs cursor-pointer hover:opacity-80"
+                                      onClick={() => {
+                                        const imageNameOnly = imageName.split(':')[0];
+                                        router.push(`/image/${encodeURIComponent(imageNameOnly)}`);
+                                      }}
                                     >
                                       <IconX className="w-3 h-3 mr-1" />
                                       {imageName}


### PR DESCRIPTION
## Summary
- Added clickable navigation to affected images badges in vulnerability library
- Added clickable navigation to false positive badges in vulnerability library
- Both badge types now navigate to `/image/[imageName]` pages for detailed image information

## Changes
- Updated `/app/harborguard/src/app/library/page.tsx` to add click handlers to badges
- Image names are parsed to remove tags before navigation (splits on `:` and takes first part)
- Added `stopPropagation()` to prevent row click interference
- Added hover effects (`hover:opacity-80`) for better user experience

## Test Plan
- [x] Click on affected image badges → navigates to correct image page
- [x] Click on false positive badges → navigates to correct image page
- [x] Hover over badges shows visual feedback
- [x] Clicking badges doesn't trigger row click event