### PR TITLE
fix: Resolve scan queue metadata Prisma error

### DIFF
--- a/src/lib/scanner/ScannerService.ts
+++ b/src/lib/scanner/ScannerService.ts
@@ -72,10 +72,9 @@ export class ScannerService {
 
     if (queued) {
       logger.info(`Scan ${requestId} queued at position ${queuePosition}`);
-      // Update database to reflect queued status
+      // Update database to reflect queued status (without queuePosition in metadata)
       await this.databaseAdapter.updateScanRecord(scanId, {
-        status: 'PENDING',
-        metadata: { queuePosition } as any
+        status: 'PENDING'
       });
     }
 


### PR DESCRIPTION
## Summary
Fixes Prisma error when queueing scans due to incorrect metadata field update.

## Problem
After the database schema migration, the `metadata` field is now a relation to the `ScanMetadata` table instead of a JSON field. The code was attempting to update it directly with `queuePosition`, causing a Prisma validation error.

## Solution
Removed the queuePosition from the metadata update since:
- Queue position is temporary and doesn't need to be persisted in the database
- The scan status is still correctly updated to 'PENDING' when queued
- The queue position is returned in the API response for immediate use

## Error Fixed
```
Invalid `prisma.scan.update()` invocation:
Unknown argument `queuePosition`. Available options are marked with ?.
```

## Testing
- Scans now queue properly without errors
- Queue position is still returned in API responses
- Scan status correctly updates to PENDING when queued