### PR TITLE
Fix duplicate key warning in Docker image selector

### DIFF
--- a/src/components/docker-image-selector.tsx
+++ b/src/components/docker-image-selector.tsx
@@ -181,9 +181,9 @@ export function DockerImageSelector({ onImageSelect, disabled, className }: Dock
 
       {isOpen && filteredImages.length > 0 && (
         <div className="z-50 w-full mt-1 bg-popover border rounded-md shadow-lg max-h-72 overflow-y-auto">
-          {filteredImages.map((image) => (
+          {filteredImages.map((image, index) => (
             <Button
-              key={image.id}
+              key={`${image.repository}-${image.tag}-${image.id}-${index}`}
               variant="ghost"
               className="w-full justify-start p-3 h-auto text-left hover:bg-muted/50"
               onClick={() => handleImageSelect(image)}


### PR DESCRIPTION
## Summary
- Resolves React warning about duplicate keys in Docker image selector component
- Uses composite key to ensure uniqueness across all Docker images

## Problem
The Docker image selector was using truncated image IDs (12 characters) as React keys. When multiple images shared the same ID prefix, React would throw a warning about duplicate keys.

## Solution
Changed the key from a simple `image.id` to a composite key: `${image.repository}-${image.tag}-${image.id}-${index}`

This ensures each item has a unique key even when image IDs collide.

## Test Plan
- [x] Verified no duplicate key warnings in browser console
- [x] Tested Docker image selector functionality remains unchanged
- [x] Confirmed images can still be selected and searched properly