### PR TITLE
Fix: Resolve UI blocking issue when opening modals from context menus

### DIFF
--- a/src/components/historical-scans-table.tsx
+++ b/src/components/historical-scans-table.tsx
@@ -373,7 +373,12 @@ export function HistoricalScansTable({ data, imageId, onScanDeleted }: Historica
                 </ContextMenuTrigger>
                 <ContextMenuContent>
                   <ContextMenuItem 
-                    onClick={() => handleExport(scan)}
+                    onClick={() => {
+                      // Delay to ensure context menu closes before modal opens
+                      setTimeout(() => {
+                        handleExport(scan)
+                      }, 150)
+                    }}
                     className="flex items-center"
                   >
                     <IconUpload className="mr-2 h-4 w-4" />
@@ -381,7 +386,12 @@ export function HistoricalScansTable({ data, imageId, onScanDeleted }: Historica
                   </ContextMenuItem>
                   <ContextMenuItem 
                     className="text-red-600 focus:text-red-600 focus:bg-red-50"
-                    onClick={() => handleDeleteClick(scan.scanId)}
+                    onClick={() => {
+                      // Delay to ensure context menu closes before modal opens
+                      setTimeout(() => {
+                        handleDeleteClick(scan.scanId)
+                      }, 150)
+                    }}
                   >
                     <IconTrash className="mr-2 h-4 w-4" />
                     Delete Scan


### PR DESCRIPTION
## Problem
When modals (Export to Registry, Delete Scan) are triggered from context menus in tables, the UI becomes unresponsive after closing the modal. Users can still highlight text but cannot click on any elements.

## Root Cause
The issue occurs due to conflicting portal systems:
1. Context menu renders in a portal at document root
2. Modal/Dialog also renders in a portal at document root
3. When a modal is triggered while the context menu is closing, the context menu portal doesn't clean up properly
4. This leaves an invisible overlay that blocks all pointer events

## Solution
Added a 150ms delay before opening modals from context menu actions. This ensures:
- Context menu portal fully closes and cleans up
- No overlapping portal animations
- Clean modal opening without stuck overlays

## Changes
- Modified historical scans table context menu actions
- Added delay to "Export to Registry" action
- Added delay to "Delete Scan" action

## Testing
1. Navigate to a scan details page with historical scans table
2. Right-click on a scan row
3. Select "Export to Registry" or "Delete Scan"
4. Close the modal
5. Verify UI remains interactive (can click buttons, links, etc.)

## Impact
This fix ensures smooth user experience when using context menus to trigger modals throughout the application.