### PR TITLE
Fix: Allow removing CVE comments by setting empty text

### DIFF
--- a/src/app/api/images/[id]/cve-classifications/[cveId]/route.ts
+++ b/src/app/api/images/[id]/cve-classifications/[cveId]/route.ts
@@ -5,8 +5,8 @@ import { recalculateImageRiskScores } from '@/lib/scan-aggregations-server';
 
 const UpdateCveClassificationSchema = z.object({
   isFalsePositive: z.boolean().optional(),
-  comment: z.string().optional(),
-  createdBy: z.string().optional(),
+  comment: z.string().nullable().optional(),
+  createdBy: z.string().nullable().optional(),
 });
 
 interface RouteParams {

--- a/src/app/api/images/[id]/cve-classifications/route.ts
+++ b/src/app/api/images/[id]/cve-classifications/route.ts
@@ -8,8 +8,8 @@ const CveClassificationSchema = z.object({
   cveId: z.string().min(1, 'CVE ID is required'),
   packageName: z.string().min(1, 'Package name is required'),
   isFalsePositive: z.boolean().optional().default(false),
-  comment: z.string().optional(),
-  createdBy: z.string().optional(),
+  comment: z.string().nullable().optional(),
+  createdBy: z.string().nullable().optional(),
 });
 
 interface RouteParams {
@@ -138,7 +138,7 @@ export async function POST(
       validatedData.cveId,
       image.name,
       validatedData.isFalsePositive,
-      validatedData.comment
+      validatedData.comment ?? undefined
     );
 
     // Recalculate risk scores for all scans of this image

--- a/src/app/api/images/name/[name]/cve-classifications/route.ts
+++ b/src/app/api/images/name/[name]/cve-classifications/route.ts
@@ -7,8 +7,8 @@ import { recalculateImageRiskScores } from '@/lib/scan-aggregations-server';
 const CveClassificationSchema = z.object({
   cveId: z.string().min(1, 'CVE ID is required'),
   isFalsePositive: z.boolean().optional().default(false),
-  comment: z.string().optional(),
-  createdBy: z.string().optional(),
+  comment: z.string().nullable().optional(),
+  createdBy: z.string().nullable().optional(),
 });
 
 interface RouteParams {
@@ -181,7 +181,7 @@ export async function POST(
       validatedData.cveId,
       imageName,
       validatedData.isFalsePositive,
-      validatedData.comment
+      validatedData.comment ?? undefined
     );
 
     // Recalculate risk scores for affected images

--- a/src/app/api/scans/[id]/cve-classifications/route.ts
+++ b/src/app/api/scans/[id]/cve-classifications/route.ts
@@ -6,8 +6,8 @@ const CveClassificationSchema = z.object({
   cveId: z.string().min(1, 'CVE ID is required'),
   packageName: z.string().min(1, 'Package name is required'),
   isFalsePositive: z.boolean().optional().default(false),
-  comment: z.string().optional(),
-  createdBy: z.string().optional(),
+  comment: z.string().nullable().optional(),
+  createdBy: z.string().nullable().optional(),
 });
 
 interface RouteParams {

--- a/src/components/cve-classification-dialog.tsx
+++ b/src/components/cve-classification-dialog.tsx
@@ -25,8 +25,8 @@ interface CveClassificationDialogProps {
   onSave: (data: { 
     cveId: string;
     isFalsePositive: boolean;
-    comment?: string;
-    createdBy?: string;
+    comment?: string | null;
+    createdBy?: string | null;
   }) => Promise<void>
 }
 
@@ -51,8 +51,8 @@ export function CveClassificationDialog({
       await onSave({
         cveId,
         isFalsePositive,
-        comment: comment.trim() || undefined,
-        createdBy: createdBy.trim() || undefined,
+        comment: comment.trim() || null,
+        createdBy: createdBy.trim() || null,
       })
       onClose()
     } catch (error) {

--- a/src/generated/openapi.json
+++ b/src/generated/openapi.json
@@ -1321,54 +1321,6 @@
         ]
       }
     },
-    "/api/scans/{id}/findings/compliance": {
-      "get": {
-        "summary": "GET /api/scans/{id}/findings/compliance",
-        "tags": [
-          "Scans"
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful response"
-          }
-        },
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "id parameter"
-          }
-        ]
-      }
-    },
-    "/api/scans/{id}/findings/packages": {
-      "get": {
-        "summary": "GET /api/scans/{id}/findings/packages",
-        "tags": [
-          "Scans"
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful response"
-          }
-        },
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "id parameter"
-          }
-        ]
-      }
-    },
     "/api/scans/{id}/findings": {
       "get": {
         "summary": "GET /api/scans/{id}/findings",
@@ -1396,54 +1348,6 @@
     "/api/scans/{id}/findings/vulnerabilities": {
       "get": {
         "summary": "GET /api/scans/{id}/findings/vulnerabilities",
-        "tags": [
-          "Scans"
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful response"
-          }
-        },
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "id parameter"
-          }
-        ]
-      }
-    },
-    "/api/scans/{id}/optimized": {
-      "get": {
-        "summary": "GET /api/scans/{id}/optimized",
-        "tags": [
-          "Scans"
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful response"
-          }
-        },
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "id parameter"
-          }
-        ]
-      }
-    },
-    "/api/scans/{id}/packages": {
-      "get": {
-        "summary": "GET /api/scans/{id}/packages",
         "tags": [
           "Scans"
         ],


### PR DESCRIPTION
## Summary
- Fixes #47 - Users can now remove CVE comments by clearing the text field
- Updates validation schemas to properly handle null values for comments
- Frontend now sends null instead of undefined for empty strings

## Changes
- Modified validation schemas in API endpoints to accept `nullable()` for comment and createdBy fields
- Updated frontend dialog to send `null` when comment is empty (instead of `undefined`)
- Added null coalescing when passing values to audit logger to prevent type errors

## Test Plan
- [x] Build passes without errors
- [ ] User can add a CVE comment
- [ ] User can clear the comment field and save to remove the comment
- [ ] Audit logs properly record comment changes

Closes #47