### PR TITLE
Fix: Check scanner activation before reading results file

### DIFF
--- a/src/lib/scanner/ScanExecutor.ts
+++ b/src/lib/scanner/ScanExecutor.ts
@@ -359,6 +359,13 @@ export class ScanExecutor implements IScanExecutor {
     const reportFiles = ['trivy.json', 'grype.json', 'syft.json', 'dockle.json', 'osv.json', 'dive.json', 'metadata.json'];
     
     for (const filename of reportFiles) {
+      const scannerName = filename.replace('.json', '');
+
+      // Check if the scanner is enabled before reading the file
+      if (!config.enabledScanners.includes(scannerName)) {
+          logger.debug(`Scanner ${scannerName} not enabled, skipping file ${filename}`);
+          continue;
+      }      
       const filePath = path.join(reportDir, filename);
       try {
         const content = await fs.readFile(filePath, 'utf8');


### PR DESCRIPTION
**Summary**
Fix the warning message in the log in case not all scanners are enabled.

**Solution**
Test if the current scanner is enabled before proceeding to read the file.

**Test Plan**
Test by disabling one or more scanners and verify that the related warning message no longer appears.