### PR TITLE
Fix integer overflow when storing large Docker image sizes

### DIFF
--- a/prisma/migrations/20250916210221_fix_integer_overflow_image_size/migration.sql
+++ b/prisma/migrations/20250916210221_fix_integer_overflow_image_size/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."images" ALTER COLUMN "sizeBytes" SET DATA TYPE BIGINT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,7 +17,7 @@ model Image {
   source                   ImageSource          @default(REGISTRY)
   digest                   String               @unique
   platform                 String?
-  sizeBytes                Int?
+  sizeBytes                BigInt?
   createdAt                DateTime             @default(now())
   updatedAt                DateTime             @updatedAt
   primaryRepositoryId      String?

--- a/src/app/api/images/[id]/route.ts
+++ b/src/app/api/images/[id]/route.ts
@@ -31,12 +31,12 @@ export async function GET(
     // Convert BigInt to string for JSON serialization (if needed)
     const serializedImage = {
       ...image,
-      sizeBytes: image.sizeBytes || null,
+      sizeBytes: image.sizeBytes ? image.sizeBytes.toString() : null,
       scans: image.scans.map(scan => ({
         ...scan,
         image: {
           ...scan.image,
-          sizeBytes: scan.image.sizeBytes || null
+          sizeBytes: scan.image.sizeBytes ? scan.image.sizeBytes.toString() : null
         }
       }))
     }

--- a/src/app/api/scans/local-bulk/route.ts
+++ b/src/app/api/scans/local-bulk/route.ts
@@ -67,7 +67,7 @@ export async function POST(request: NextRequest) {
               tag: image.tag,
               source: 'LOCAL_DOCKER',
               platform: 'linux/amd64',
-              sizeBytes: parseInt(image.size.replace(/[^\d]/g, '')) * 1024 * 1024, // Convert MB to bytes
+              sizeBytes: BigInt(parseInt(image.size.replace(/[^\d]/g, '')) * 1024 * 1024), // Convert MB to bytes
               updatedAt: new Date()
             },
             create: {
@@ -76,7 +76,7 @@ export async function POST(request: NextRequest) {
               digest: imageDigest,
               source: 'LOCAL_DOCKER',
               platform: 'linux/amd64',
-              sizeBytes: parseInt(image.size.replace(/[^\d]/g, '')) * 1024 * 1024, // Convert MB to bytes
+              sizeBytes: BigInt(parseInt(image.size.replace(/[^\d]/g, '')) * 1024 * 1024), // Convert MB to bytes
             }
           });
           

--- a/src/app/api/scans/upload/route.ts
+++ b/src/app/api/scans/upload/route.ts
@@ -86,7 +86,7 @@ export async function POST(request: NextRequest) {
           source: 'REGISTRY',
           digest: validatedData.image.digest,
           platform: validatedData.image.platform,
-          sizeBytes: validatedData.image.sizeBytes || null,
+          sizeBytes: validatedData.image.sizeBytes ? BigInt(validatedData.image.sizeBytes) : null,
         }
       })
     }

--- a/src/app/image/[name]/page.tsx
+++ b/src/app/image/[name]/page.tsx
@@ -410,7 +410,7 @@ export default function ImageDetailsPage() {
                   <p className="text-sm">
                     {imageData.latestImage?.sizeBytes
                       ? Math.round(
-                          (imageData.latestImage.sizeBytes || 0) / 1024 / 1024
+                          Number(imageData.latestImage.sizeBytes || 0) / 1024 / 1024
                         )
                       : 0}{" "}
                     MB

--- a/src/app/image/[name]/scan/[scanId]/page.tsx
+++ b/src/app/image/[name]/scan/[scanId]/page.tsx
@@ -2170,7 +2170,7 @@ export default function ScanResultsPage() {
                           <IconStack className="h-3 w-3" />
                           Layer {layer.index + 1}
                           <Badge variant="secondary" className="text-xs ml-1">
-                            {(layer.sizeBytes / (1024 * 1024)).toFixed(1)}MB
+                            {(Number(layer.sizeBytes) / (1024 * 1024)).toFixed(1)}MB
                           </Badge>
                         </TabsTrigger>
                       ))}
@@ -2189,7 +2189,7 @@ export default function ScanResultsPage() {
                                 Layer {layer.index + 1}
                               </Badge>
                               <span className="text-sm text-muted-foreground">
-                                {(layer.sizeBytes / (1024 * 1024)).toFixed(2)}{" "}
+                                {(Number(layer.sizeBytes) / (1024 * 1024)).toFixed(2)}{" "}
                                 MB
                               </span>
                             </div>

--- a/src/lib/type-utils.ts
+++ b/src/lib/type-utils.ts
@@ -127,7 +127,7 @@ export function scanToLegacyScan(scan: ScanWithImage, vulnCount?: VulnerabilityC
     image: scan.image?.name || 'unknown',
     digestShort: scan.image?.digest?.slice(7, 19) || '', // First 12 chars after "sha256:"
     platform: scan.image?.platform || 'unknown',
-    sizeMb: scan.image?.sizeBytes ? Math.round(scan.image.sizeBytes / 1024 / 1024) : 0,
+    sizeMb: scan.image?.sizeBytes ? Math.round(Number(scan.image.sizeBytes) / 1024 / 1024) : 0,
     riskScore: scan.riskScore || 0,
     
     // Map vulnerability counts


### PR DESCRIPTION
## Summary
Fixes #90 - Integer overflow error when scanning Docker images larger than ~2.14GB

## Problem
The `Image.sizeBytes` field was using PostgreSQL's INT4 (32-bit signed integer) which can only store values up to 2,147,483,647. Docker images larger than this size (approximately 2.14GB) would cause an integer overflow error during scanning.

## Solution
Changed the `sizeBytes` field from `Int?` to `BigInt?` throughout the codebase to support values up to 9,223,372,036,854,775,807 bytes (~9.2 exabytes).

## Changes
- **Schema**: Changed `Image.sizeBytes` from `Int?` to `BigInt?` in Prisma schema
- **Database**: Generated and applied migration to alter column type to BIGINT
- **Backend**: Updated DatabaseAdapter to use `BigInt()` for size conversions
- **API**: Fixed serialization to convert BigInt to strings for JSON responses
- **Frontend**: Updated components to convert BigInt strings back to numbers for calculations

## Testing
✅ Tested with the original failing value (2,741,759,137 bytes)
✅ Verified with larger values up to 100GB
✅ All type checks pass
✅ Build completes successfully

## Test Results
```
✅ Successfully created image with size 2741759137 bytes (2.55 GB)
✅ Successfully created image with size 5000000000 bytes (4.66 GB)
✅ Successfully created image with size 10000000000 bytes (9.31 GB)
✅ Successfully created image with size 100000000000 bytes (93.13 GB)
```