### PR TITLE
feat: Protect user IPs in demo mode

### DIFF
--- a/src/app/api/audit-logs/route.ts
+++ b/src/app/api/audit-logs/route.ts
@@ -167,10 +167,13 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Protect IP in demo mode
+    const protectedIp = process.env.NEXT_PUBLIC_DEMO_MODE === 'true' ? 'DEMO_PROTECT' : body.userIp;
+
     const auditLogData = {
       eventType: mapEventType(body.eventType),
       category: mapLogCategory(body.category),
-      userIp: body.userIp,
+      userIp: protectedIp,
       userAgent: body.userAgent || null,
       userId: body.userId || null,
       resource: body.resource || null,

--- a/src/lib/audit-logger.ts
+++ b/src/lib/audit-logger.ts
@@ -77,23 +77,28 @@ export interface AuditLogData {
  * Extract user IP from Next.js request
  */
 export function getUserIpFromRequest(request: NextRequest): string {
+  // Check if DEMO_MODE is enabled
+  if (process.env.NEXT_PUBLIC_DEMO_MODE === 'true') {
+    return 'DEMO_PROTECT';
+  }
+
   // Check various headers for IP address
   const forwarded = request.headers.get('x-forwarded-for');
   const realIp = request.headers.get('x-real-ip');
   const cfConnectingIp = request.headers.get('cf-connecting-ip');
-  
+
   if (forwarded) {
     return forwarded.split(',')[0].trim();
   }
-  
+
   if (realIp) {
     return realIp;
   }
-  
+
   if (cfConnectingIp) {
     return cfConnectingIp;
   }
-  
+
   // No IP address available
   return 'unknown';
 }
@@ -203,10 +208,13 @@ export const auditLogger = {
    * Log scan completion
    */
   scanComplete: async (userIp: string, imageName: string, scanId: string) => {
+    // Protect IP in demo mode
+    const protectedIp = process.env.NEXT_PUBLIC_DEMO_MODE === 'true' ? 'DEMO_PROTECT' : userIp;
+
     await logAuditEvent({
       eventType: 'scan_complete',
       category: 'informative',
-      userIp,
+      userIp: protectedIp,
       action: `Completed scan for ${imageName}`,
       resource: imageName,
       details: { scanId, imageName }
@@ -291,10 +299,13 @@ export const auditLogger = {
    * Log system errors
    */
   systemError: async (userIp: string, error: string, context?: Record<string, any>) => {
+    // Protect IP in demo mode
+    const protectedIp = process.env.NEXT_PUBLIC_DEMO_MODE === 'true' ? 'DEMO_PROTECT' : userIp;
+
     await logAuditEvent({
       eventType: 'system_error',
       category: 'error',
-      userIp,
+      userIp: protectedIp,
       action: `System error: ${error}`,
       details: { error, context }
     });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -37,22 +37,27 @@ function shouldLogRoute(pathname: string): boolean {
 }
 
 function getUserIp(request: NextRequest): string {
+  // Check if DEMO_MODE is enabled
+  if (process.env.NEXT_PUBLIC_DEMO_MODE === 'true') {
+    return 'DEMO_PROTECT';
+  }
+
   const forwarded = request.headers.get('x-forwarded-for');
   const realIp = request.headers.get('x-real-ip');
   const cfConnectingIp = request.headers.get('cf-connecting-ip');
-  
+
   if (forwarded) {
     return forwarded.split(',')[0].trim();
   }
-  
+
   if (realIp) {
     return realIp;
   }
-  
+
   if (cfConnectingIp) {
     return cfConnectingIp;
   }
-  
+
   return 'unknown';
 }
 


### PR DESCRIPTION
## Summary
- Adds IP address protection when `NEXT_PUBLIC_DEMO_MODE=true`
- Replaces all real IP addresses with "DEMO_PROTECT" in audit logs
- Ensures user privacy in public demo environments

## Changes
- Modified `getUserIpFromRequest()` in `src/lib/audit-logger.ts` to return "DEMO_PROTECT" in demo mode
- Updated `getUserIp()` in `src/middleware.ts` to mask IPs when demo mode is enabled  
- Added IP protection in `src/app/api/audit-logs/route.ts` for API-created logs
- Also protects IPs in `scanComplete()` and `systemError()` audit logger methods

## Test plan
- [x] Set `NEXT_PUBLIC_DEMO_MODE=true` in environment
- [x] Create audit log entries through various actions (page views, scans, API calls)
- [x] Verify all IP addresses appear as "DEMO_PROTECT" in the audit logs
- [x] Confirm normal IP logging works when demo mode is disabled