### PR TITLE
Fix: Multi-arch Docker builds - Ensure correct architecture binaries for scanners

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,12 +39,26 @@ RUN apk add --no-cache \
   && echo "Building for architecture: ${TARGETARCH:-not set}" \
   # Set default if TARGETARCH is not provided
   && TARGETARCH="${TARGETARCH:-amd64}" \
+  # Create a fake uname that returns the correct architecture for the target platform
+  && echo '#!/bin/sh' > /usr/local/bin/uname \
+  && echo 'if [ "$1" = "-m" ]; then' >> /usr/local/bin/uname \
+  && echo '  case "${TARGETARCH}" in' >> /usr/local/bin/uname \
+  && echo '    arm64) echo "aarch64" ;;' >> /usr/local/bin/uname \
+  && echo '    amd64) echo "x86_64" ;;' >> /usr/local/bin/uname \
+  && echo '    *) echo "x86_64" ;;' >> /usr/local/bin/uname \
+  && echo '  esac' >> /usr/local/bin/uname \
+  && echo 'else' >> /usr/local/bin/uname \
+  && echo '  /bin/uname "$@"' >> /usr/local/bin/uname \
+  && echo 'fi' >> /usr/local/bin/uname \
+  && chmod +x /usr/local/bin/uname \
   # Install Trivy
   && curl -sSfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin "${TRIVY_VERSION}" \
-  # Install Grype
+  # Install Grype (will use our fake uname)
   && curl -fsSL https://get.anchore.io/grype | sh -s -- -b /usr/local/bin \
-  # Install Syft
+  # Install Syft (will use our fake uname)
   && curl -sSfL https://get.anchore.io/syft | sh -s -- -b /usr/local/bin \
+  # Remove the fake uname after installation
+  && rm /usr/local/bin/uname \
   # Install OSV Scanner
   && curl -L "https://github.com/google/osv-scanner/releases/download/${OSV_SCANNER_VERSION}/osv-scanner_linux_${TARGETARCH}" -o /usr/local/bin/osv-scanner \
   && chmod +x /usr/local/bin/osv-scanner \


### PR DESCRIPTION
## Summary
- Fixes issue where ARM64 Docker images contained x86_64 binaries for Grype and Syft
- Ensures multi-architecture builds produce correct binaries for each platform
- Resolves #100 where Grype executable was missing/broken in certain builds

## Problem
During multi-architecture Docker builds, the Grype and Syft installation scripts use `uname -m` to detect the system architecture. However, this returns the build host architecture (typically x86_64 in GitHub Actions) rather than the target architecture (e.g., arm64), causing ARM64 images to receive x86_64 binaries.

This resulted in:
- ARM64 users getting "exec format error" 
- Grype appearing to be missing (it existed but couldn't execute)
- Inconsistent build failures

## Solution
Created a temporary `uname` override that returns the correct architecture based on Docker's `$TARGETARCH` build argument:
- Places a fake `uname` script in `/usr/local/bin` (higher PATH priority)
- Maps `TARGETARCH` values to what the install scripts expect
- Removes the override after installation completes

## Testing
✅ Tested locally with Docker buildx for both architectures:
- AMD64 builds correctly install x86_64 binaries
- ARM64 builds correctly install aarch64 binaries
- Verified binary formats with ELF header inspection

## Changes
- Modified `Dockerfile` to add uname override before Grype/Syft installation
- Override is removed immediately after installation to avoid side effects

This ensures all users get working scanner binaries regardless of their architecture.