### PR TITLE
[#112] fix: respect Docker Hub tab selection for namespace images

### DIFF
--- a/src/lib/scanner/DatabaseAdapter.ts
+++ b/src/lib/scanner/DatabaseAdapter.ts
@@ -12,7 +12,7 @@ const execAsync = promisify(exec);
 
 export class DatabaseAdapter implements IDatabaseAdapter {
   private repositoryService: RepositoryService;
-  
+
   constructor() {
     this.repositoryService = RepositoryService.getInstance(prisma);
   }
@@ -21,7 +21,7 @@ export class DatabaseAdapter implements IDatabaseAdapter {
     if (this.isLocalDockerScan(request)) {
       return this.initializeLocalDockerScanRecord(requestId, request);
     }
-    
+
     if (request.source === 'tar' && request.tarPath) {
       return this.initializeTarScanRecord(requestId, request);
     }
@@ -34,12 +34,12 @@ export class DatabaseAdapter implements IDatabaseAdapter {
     if (request.source === 'local') {
       return true;
     }
-    
+
     // Legacy check: if registry is 'local', treat as local Docker scan
     if (request.registry === 'local') {
       return true;
     }
-    
+
     return false;
   }
 
@@ -49,9 +49,9 @@ export class DatabaseAdapter implements IDatabaseAdapter {
       const imageRef = request.dockerImageId || `${request.image}:${request.tag}`;
       const imageData = await inspectDockerImage(imageRef);
       const digest = imageData.Id;
-      
+
       let image = await prisma.image.findUnique({ where: { digest } });
-      
+
       if (!image) {
         image = await prisma.image.create({
           data: {
@@ -90,7 +90,7 @@ export class DatabaseAdapter implements IDatabaseAdapter {
       // For tar files, we don't need to inspect from registry
       // Create a unique digest based on the tar path and timestamp
       const digest = `sha256:tar-${Date.now()}-${Math.random().toString(36).substring(7)}`;
-      
+
       const image = await prisma.image.create({
         data: {
           name: request.image,
@@ -124,12 +124,18 @@ export class DatabaseAdapter implements IDatabaseAdapter {
   private async initializeRegistryScanRecord(requestId: string, request: ScanRequest) {
     // Declare imageRef outside try block so it's accessible in catch block
     let imageRef = '';
-    
+
     try {
-      // Get registry URL from repository service
-      let registryUrl = await this.repositoryService.getRegistryUrl(request.repositoryId, request.image) || request.registry;
+      // Prioritize explicit registry from request over auto-detection
+      // This ensures Docker Hub tab selection is respected
+      let registryUrl = request.registry;
       let cleanImageName = request.image;
-      
+
+      // Only use repository service if no explicit registry was provided
+      if (!registryUrl) {
+        registryUrl = await this.repositoryService.getRegistryUrl(request.repositoryId, request.image) || undefined;
+      }
+
       // Extract registry URL from image name if present
       if (request.image.includes('/')) {
         const parts = request.image.split('/');
@@ -137,7 +143,7 @@ export class DatabaseAdapter implements IDatabaseAdapter {
         if (parts[0].includes(':') || parts[0].includes('.')) {
           const extractedRegistry = parts[0];
           const extractedImageName = parts.slice(1).join('/');
-          
+
           if (!registryUrl) {
             // No repository found, use the extracted registry
             registryUrl = extractedRegistry;
@@ -148,12 +154,12 @@ export class DatabaseAdapter implements IDatabaseAdapter {
           }
         }
       }
-      
+
       // If cleanImageName already starts with the registry URL, remove it to avoid duplication
       if (registryUrl && cleanImageName.startsWith(`${registryUrl}/`)) {
         cleanImageName = cleanImageName.substring(registryUrl.length + 1);
       }
-      
+
       // If we still don't have a registry URL, check if we have a registry type hint
       if (!registryUrl && request.registryType) {
         // Use registry type hint to determine the registry URL
@@ -175,7 +181,7 @@ export class DatabaseAdapter implements IDatabaseAdapter {
             break;
         }
       }
-      
+
       // If we still don't have a registry URL, we need to handle this case
       if (!registryUrl) {
         // Check if the image name itself already contains a registry
@@ -210,13 +216,13 @@ export class DatabaseAdapter implements IDatabaseAdapter {
         // Try to find a repository for this image
         repository = await this.repositoryService.findForImage(request.image);
       }
-      
+
       if (!repository) {
         // Create a temporary repository based on the registry URL and type hint
         let repoType: 'DOCKERHUB' | 'GHCR' | 'GENERIC' | 'ECR' | 'GCR' = 'DOCKERHUB';
         let repoName = 'Docker Hub';
         let repoUrl = registryUrl || 'docker.io';
-        
+
         // Use registryType hint if provided
         if (request.registryType) {
           if (request.registryType === 'GITLAB') {
@@ -269,7 +275,7 @@ export class DatabaseAdapter implements IDatabaseAdapter {
             repoName = 'Generic Registry';
           }
         }
-        
+
         repository = {
           id: 'temp',
           name: repoName,
@@ -290,7 +296,7 @@ export class DatabaseAdapter implements IDatabaseAdapter {
           updatedAt: new Date()
         } as Repository;
       }
-      
+
       // Use registry handler for all operations
       console.log('[DatabaseAdapter] Creating provider for repository type:', repository.type);
       const provider = RegistryProviderFactory.createFromRepository(repository);
@@ -331,7 +337,7 @@ export class DatabaseAdapter implements IDatabaseAdapter {
         create: imageData
       });
 
-        // Create repository-image relationship if repository ID is provided
+      // Create repository-image relationship if repository ID is provided
       if (request.repositoryId && image) {
         await prisma.repositoryImage.upsert({
           where: {
@@ -394,23 +400,23 @@ export class DatabaseAdapter implements IDatabaseAdapter {
     };
 
     await this.updateScanRecord(scanId, updateData);
-    
+
     // Create or update ScanMetadata record (keeps JSONB for downloads)
     const metadataId = await this.createOrUpdateScanMetadata(scanId, reports);
-    
+
     // Save to individual scanner result tables for fast queries
     await this.saveScannerResultTables(metadataId, reports);
-    
+
     // Populate normalized finding tables
     await this.populateNormalizedFindings(scanId, reports);
-    
+
     // Calculate aggregated data
     await this.calculateAggregatedData(scanId, reports, metadataId);
   }
-  
+
   async createOrUpdateScanMetadata(scanId: string, reports: ScanReports): Promise<string> {
     const metadata = reports.metadata || {};
-    
+
     const scanMetadataData = {
       // Docker Image metadata
       dockerId: metadata.Id || null,
@@ -431,7 +437,7 @@ export class DatabaseAdapter implements IDatabaseAdapter {
       dockerMetadata: metadata.Metadata || null,
       dockerLabels: metadata.Labels || metadata.Config?.Labels || null,
       dockerEnv: metadata.Env || metadata.Config?.Env || null,
-      
+
       // Scan Results
       trivyResults: reports.trivy || null,
       grypeResults: reports.grype || null,
@@ -439,19 +445,19 @@ export class DatabaseAdapter implements IDatabaseAdapter {
       dockleResults: reports.dockle || null,
       osvResults: reports.osv || null,
       diveResults: reports.dive || null,
-      
+
       // Scanner versions
       scannerVersions: metadata.scannerVersions || null
     };
-    
+
     // Check if scan already has metadata
     const scan = await prisma.scan.findUnique({
       where: { id: scanId },
       select: { metadataId: true }
     });
-    
+
     let metadataId: string;
-    
+
     if (scan?.metadataId) {
       // Update existing metadata
       await prisma.scanMetadata.update({
@@ -465,14 +471,14 @@ export class DatabaseAdapter implements IDatabaseAdapter {
         data: scanMetadataData
       });
       metadataId = newMetadata.id;
-      
+
       // Link to scan
       await prisma.scan.update({
         where: { id: scanId },
         data: { metadataId }
       });
     }
-    
+
     return metadataId;
   }
 
@@ -485,23 +491,23 @@ export class DatabaseAdapter implements IDatabaseAdapter {
       if (reports.grype) {
         await this.saveGrypeResults(metadataId, reports.grype);
       }
-      
+
       if (reports.trivy) {
         await this.saveTrivyResults(metadataId, reports.trivy);
       }
-      
+
       if (reports.dive) {
         await this.saveDiveResults(metadataId, reports.dive);
       }
-      
+
       if (reports.syft) {
         await this.saveSyftResults(metadataId, reports.syft);
       }
-      
+
       if (reports.dockle) {
         await this.saveDockleResults(metadataId, reports.dockle);
       }
-      
+
       if (reports.osv) {
         await this.saveOsvResults(metadataId, reports.osv);
       }
@@ -533,9 +539,9 @@ export class DatabaseAdapter implements IDatabaseAdapter {
         packageLanguage: match.artifact?.language || null,
         fixState: match.vulnerability?.fix?.state || null,
         fixVersions: match.vulnerability?.fix?.versions || null,
-        cvssV2Score: match.vulnerability?.cvss?.[0]?.version === '2.0' ? 
+        cvssV2Score: match.vulnerability?.cvss?.[0]?.version === '2.0' ?
           match.vulnerability.cvss[0].metrics?.baseScore : null,
-        cvssV2Vector: match.vulnerability?.cvss?.[0]?.version === '2.0' ? 
+        cvssV2Vector: match.vulnerability?.cvss?.[0]?.version === '2.0' ?
           match.vulnerability.cvss[0].vector : null,
         cvssV3Score: match.vulnerability?.cvss?.find((c: any) => c.version?.startsWith('3'))?.metrics?.baseScore || null,
         cvssV3Vector: match.vulnerability?.cvss?.find((c: any) => c.version?.startsWith('3'))?.vector || null,
@@ -631,9 +637,9 @@ export class DatabaseAdapter implements IDatabaseAdapter {
             code: secret.Code || null,
             match: secret.Match || null,
             // Handle Layer being an object with DiffID
-            layer: typeof secret.Layer === 'object' && secret.Layer ? 
-                   (secret.Layer.DiffID || secret.Layer.Digest || JSON.stringify(secret.Layer)) : 
-                   secret.Layer || null,
+            layer: typeof secret.Layer === 'object' && secret.Layer ?
+              (secret.Layer.DiffID || secret.Layer.Digest || JSON.stringify(secret.Layer)) :
+              secret.Layer || null,
           }));
 
           await prisma.trivySecret.createMany({ data: secrets });
@@ -708,7 +714,7 @@ export class DatabaseAdapter implements IDatabaseAdapter {
             cpeString = firstCpe.value;
           }
         }
-        
+
         return {
           syftResultsId: syftResult.id,
           packageId: artifact.id || '',
@@ -760,7 +766,7 @@ export class DatabaseAdapter implements IDatabaseAdapter {
     });
 
     const vulnerabilities: any[] = [];
-    
+
     if (osvData.results && osvData.results.length > 0) {
       for (const result of osvData.results) {
         if (result.packages) {
@@ -803,7 +809,7 @@ export class DatabaseAdapter implements IDatabaseAdapter {
     const vulnCount: VulnerabilityCount = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
     let totalCvssScore = 0;
     let cvssCount = 0;
-    
+
     // Aggregate vulnerabilities from Trivy
     if (reports.trivy?.Results) {
       for (const result of reports.trivy.Results) {
@@ -813,7 +819,7 @@ export class DatabaseAdapter implements IDatabaseAdapter {
             if (severity && vulnCount.hasOwnProperty(severity)) {
               vulnCount[severity as keyof VulnerabilityCount]++;
             }
-            
+
             if (vuln.CVSS?.redhat?.V3Score || vuln.CVSS?.nvd?.V3Score) {
               const score = vuln.CVSS.redhat?.V3Score || vuln.CVSS.nvd?.V3Score;
               totalCvssScore += score;
@@ -823,7 +829,7 @@ export class DatabaseAdapter implements IDatabaseAdapter {
         }
       }
     }
-    
+
     // Aggregate vulnerabilities from Grype
     if (reports.grype?.matches) {
       for (const match of reports.grype.matches) {
@@ -832,7 +838,7 @@ export class DatabaseAdapter implements IDatabaseAdapter {
         if (severity && vulnCount.hasOwnProperty(severity)) {
           vulnCount[severity as keyof VulnerabilityCount]++;
         }
-        
+
         // Get CVSS score from Grype
         if (match.vulnerability?.cvss) {
           for (const cvss of match.vulnerability.cvss) {
@@ -845,7 +851,7 @@ export class DatabaseAdapter implements IDatabaseAdapter {
         }
       }
     }
-    
+
     // Aggregate vulnerabilities from OSV
     if (reports.osv?.results) {
       for (const result of reports.osv.results) {
@@ -860,7 +866,7 @@ export class DatabaseAdapter implements IDatabaseAdapter {
                       const score = parseFloat(sev.score);
                       totalCvssScore += score;
                       cvssCount++;
-                      
+
                       // Map CVSS score to severity
                       if (score >= 9.0) vulnCount.critical++;
                       else if (score >= 7.0) vulnCount.high++;
@@ -882,10 +888,10 @@ export class DatabaseAdapter implements IDatabaseAdapter {
     }
 
     // Only set vulnerability count if we found any vulnerabilities
-    if (vulnCount.critical > 0 || vulnCount.high > 0 || vulnCount.medium > 0 || 
-        vulnCount.low > 0 || vulnCount.info > 0) {
+    if (vulnCount.critical > 0 || vulnCount.high > 0 || vulnCount.medium > 0 ||
+      vulnCount.low > 0 || vulnCount.info > 0) {
       aggregates.vulnerabilityCount = vulnCount;
-      
+
       const avgCvss = cvssCount > 0 ? totalCvssScore / cvssCount : 0;
       aggregates.riskScore = Math.min(100, Math.round(
         (vulnCount.critical * 25) +
@@ -900,7 +906,7 @@ export class DatabaseAdapter implements IDatabaseAdapter {
       const { fatal, warn, info, pass } = reports.dockle.summary;
       const total = fatal + warn + info + pass;
       const complianceScore = total > 0 ? Math.round((pass / total) * 100) : 0;
-      
+
       aggregates.complianceScore = {
         dockle: {
           score: complianceScore,
@@ -919,14 +925,14 @@ export class DatabaseAdapter implements IDatabaseAdapter {
       if (aggregates.riskScore !== undefined) {
         scanUpdateData.riskScore = aggregates.riskScore;
       }
-      
+
       if (Object.keys(scanUpdateData).length > 0) {
         await this.updateScanRecord(scanId, scanUpdateData);
       }
-      
+
       // Update ScanMetadata with aggregated data
       const metadataUpdateData: any = {};
-      
+
       if (aggregates.vulnerabilityCount) {
         metadataUpdateData.vulnerabilityCritical = aggregates.vulnerabilityCount.critical || 0;
         metadataUpdateData.vulnerabilityHigh = aggregates.vulnerabilityCount.high || 0;
@@ -934,11 +940,11 @@ export class DatabaseAdapter implements IDatabaseAdapter {
         metadataUpdateData.vulnerabilityLow = aggregates.vulnerabilityCount.low || 0;
         metadataUpdateData.vulnerabilityInfo = aggregates.vulnerabilityCount.info || 0;
       }
-      
+
       if (aggregates.riskScore !== undefined) {
         metadataUpdateData.aggregatedRiskScore = aggregates.riskScore;
       }
-      
+
       if (aggregates.complianceScore?.dockle) {
         const dockle = aggregates.complianceScore.dockle;
         metadataUpdateData.complianceScore = dockle.score || null;
@@ -948,7 +954,7 @@ export class DatabaseAdapter implements IDatabaseAdapter {
         metadataUpdateData.complianceInfo = dockle.info || null;
         metadataUpdateData.compliancePass = dockle.pass || null;
       }
-      
+
       // Only update metadata if we have a metadataId
       if (metadataId) {
         await prisma.scanMetadata.update({
@@ -966,16 +972,16 @@ export class DatabaseAdapter implements IDatabaseAdapter {
     try {
       // Process vulnerability findings
       await this.populateVulnerabilityFindings(scanId, reports);
-      
+
       // Process package findings
       await this.populatePackageFindings(scanId, reports);
-      
+
       // Process compliance findings
       await this.populateComplianceFindings(scanId, reports);
-      
+
       // Process efficiency findings
       await this.populateEfficiencyFindings(scanId, reports);
-      
+
       // Create cross-scanner correlations
       await this.createFindingCorrelations(scanId);
     } catch (error) {
@@ -986,7 +992,7 @@ export class DatabaseAdapter implements IDatabaseAdapter {
 
   private async populateVulnerabilityFindings(scanId: string, reports: ScanReports): Promise<void> {
     const findings: any[] = [];
-    
+
     // Process Trivy results
     if (reports.trivy?.Results) {
       for (const result of reports.trivy.Results) {
@@ -1015,7 +1021,7 @@ export class DatabaseAdapter implements IDatabaseAdapter {
         }
       }
     }
-    
+
     // Process Grype results
     if (reports.grype?.matches) {
       for (const match of reports.grype.matches) {
@@ -1040,7 +1046,7 @@ export class DatabaseAdapter implements IDatabaseAdapter {
         });
       }
     }
-    
+
     // Process OSV results
     if (reports.osv?.results) {
       for (const result of reports.osv.results) {
@@ -1069,7 +1075,7 @@ export class DatabaseAdapter implements IDatabaseAdapter {
         }
       }
     }
-    
+
     if (findings.length > 0) {
       await prisma.scanVulnerabilityFinding.createMany({ data: findings });
     }
@@ -1105,7 +1111,7 @@ export class DatabaseAdapter implements IDatabaseAdapter {
 
   private async populatePackageFindings(scanId: string, reports: ScanReports): Promise<void> {
     const findings: any[] = [];
-    
+
     // Process Syft results
     if (reports.syft?.artifacts) {
       for (const artifact of reports.syft.artifacts) {
@@ -1130,7 +1136,7 @@ export class DatabaseAdapter implements IDatabaseAdapter {
         });
       }
     }
-    
+
     // Extract packages from Trivy SBOM data
     if (reports.trivy?.Results) {
       for (const result of reports.trivy.Results) {
@@ -1156,7 +1162,7 @@ export class DatabaseAdapter implements IDatabaseAdapter {
         }
       }
     }
-    
+
     if (findings.length > 0) {
       await prisma.scanPackageFinding.createMany({ data: findings });
     }
@@ -1164,7 +1170,7 @@ export class DatabaseAdapter implements IDatabaseAdapter {
 
   private async populateComplianceFindings(scanId: string, reports: ScanReports): Promise<void> {
     const findings: any[] = [];
-    
+
     // Process Dockle results
     if (reports.dockle?.details) {
       for (const detail of reports.dockle.details) {
@@ -1187,7 +1193,7 @@ export class DatabaseAdapter implements IDatabaseAdapter {
         }
       }
     }
-    
+
     if (findings.length > 0) {
       await prisma.scanComplianceFinding.createMany({ data: findings });
     }
@@ -1195,7 +1201,7 @@ export class DatabaseAdapter implements IDatabaseAdapter {
 
   private async populateEfficiencyFindings(scanId: string, reports: ScanReports): Promise<void> {
     const findings: any[] = [];
-    
+
     // Process Dive results
     if (reports.dive?.layer) {
       for (const layer of reports.dive.layer) {
@@ -1220,7 +1226,7 @@ export class DatabaseAdapter implements IDatabaseAdapter {
         }
       }
     }
-    
+
     if (findings.length > 0) {
       await prisma.scanEfficiencyFinding.createMany({ data: findings });
     }
@@ -1232,7 +1238,7 @@ export class DatabaseAdapter implements IDatabaseAdapter {
       where: { scanId },
       select: { cveId: true, source: true, severity: true }
     });
-    
+
     // Group by CVE ID
     const correlations: Record<string, { sources: Set<string>; severities: string[] }> = {};
     for (const finding of vulnFindings) {
@@ -1245,7 +1251,7 @@ export class DatabaseAdapter implements IDatabaseAdapter {
       correlations[finding.cveId].sources.add(finding.source);
       correlations[finding.cveId].severities.push(finding.severity);
     }
-    
+
     // Create correlation records
     const correlationData: any[] = [];
     for (const [cveId, data] of Object.entries(correlations)) {
@@ -1260,7 +1266,7 @@ export class DatabaseAdapter implements IDatabaseAdapter {
         severity: this.getHighestSeverity(data.severities)
       });
     }
-    
+
     if (correlationData.length > 0) {
       await prisma.scanFindingCorrelation.createMany({ data: correlationData });
     }
@@ -1284,7 +1290,7 @@ export class DatabaseAdapter implements IDatabaseAdapter {
 
   private mapOsvSeverity(severities: any[] | undefined): any {
     if (!severities || severities.length === 0) return 'INFO';
-    
+
     for (const sev of severities) {
       if (sev.type === 'CVSS_V3' && sev.score) {
         const score = parseFloat(sev.score);
@@ -1294,19 +1300,19 @@ export class DatabaseAdapter implements IDatabaseAdapter {
         if (score >= 0.1) return 'LOW';
       }
     }
-    
+
     return 'INFO';
   }
 
   private extractOsvScore(severities: any[] | undefined): number | null {
     if (!severities || severities.length === 0) return null;
-    
+
     for (const sev of severities) {
       if (sev.type === 'CVSS_V3' && sev.score) {
         return parseFloat(sev.score);
       }
     }
-    
+
     return null;
   }
 


### PR DESCRIPTION
Fixes issue where namespace images (e.g., apache/airflow) were incorrectly routed to private registries even when explicitly selected from Docker Hub tab.

Root Cause:
- RepositoryService.findForImage() was too aggressive in assuming namespace images belonged to private registries
- DatabaseAdapter and ScanExecutor prioritized auto-detection over explicit registry selection from user's tab choice

Changes:
- Prioritize explicit registry from scan request over auto-detection
- Only use repository service lookup when no explicit registry provided
- Improve RepositoryService.findForImage() to require explicit evidence before routing to private registries
- Prevent Docker Hub images from being incorrectly routed to private registries

Files Modified:
- src/lib/scanner/DatabaseAdapter.ts: Prioritize request.registry
- src/lib/scanner/ScanExecutor.ts: Prioritize request.registry
- src/services/RepositoryService.ts: More conservative private registry detection

Testing:
- Verified apache/airflow:latest now correctly resolves to docker.io
- Verified nginx:latest continues to work correctly
- Verified GitHub Container Registry images still work correctly

Fixes: #112