### PR TITLE
Fix BigInt serialization error in patch status API

### DIFF
--- a/src/app/api/patches/[id]/status/route.ts
+++ b/src/app/api/patches/[id]/status/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
+import { serializeForJson } from '@/lib/type-utils';
 
 export async function GET(
   request: NextRequest,
@@ -30,7 +31,7 @@ export async function GET(
       totalVulnerabilities: patchOperation.vulnerabilitiesCount,
       patchedSuccessfully: patchOperation.patchedCount,
       patchesFailed: patchOperation.failedCount,
-      successRate: patchOperation.vulnerabilitiesCount > 0 
+      successRate: patchOperation.vulnerabilitiesCount > 0
         ? (patchOperation.patchedCount / patchOperation.vulnerabilitiesCount * 100).toFixed(1)
         : 0,
       duration: patchOperation.completedAt && patchOperation.startedAt
@@ -38,10 +39,10 @@ export async function GET(
         : null
     };
 
-    return NextResponse.json({
+    return NextResponse.json(serializeForJson({
       patchOperation,
       summary
-    });
+    }));
 
   } catch (error) {
     console.error('Failed to fetch patch operation status:', error);


### PR DESCRIPTION
## Summary
- Fixed "Do not know how to serialize a BigInt" error when fetching patch operation status
- Used existing `serializeForJson` utility function to handle BigInt conversion consistently

## Problem
The `/api/patches/[id]/status` endpoint was failing because the `Image` model contains a `sizeBytes` field of type `BigInt`, which cannot be directly serialized to JSON.

## Solution
Updated the endpoint to use the existing `serializeForJson` utility function that properly handles BigInt conversion throughout the codebase, ensuring consistency with other API endpoints.

## Test Plan
- [x] Verify patch status endpoint returns data without serialization errors
- [x] Confirm TypeScript compilation passes
- [x] Ensure response includes properly serialized image data with sizeBytes as strings