### PR TITLE
fix: Update route from /image to /images for consistency

### DIFF
--- a/src/app/images/[name]/[scanId]/page.tsx
+++ b/src/app/images/[name]/[scanId]/page.tsx
@@ -537,7 +537,7 @@ export default function ScanResultsPage() {
     { label: "Dashboard", href: "/" },
     {
       label: decodedImageName,
-      href: `/image/${encodeURIComponent(decodedImageName)}`,
+      href: `/images/${encodeURIComponent(decodedImageName)}`,
     },
     { label: `Scan ${scanData?.requestId}` },
   ];
@@ -808,7 +808,7 @@ export default function ScanResultsPage() {
                 may have been removed.
               </p>
               <Button asChild>
-                <a href={`/image/${encodeURIComponent(decodedImageName)}`}>
+                <a href={`/images/${encodeURIComponent(decodedImageName)}`}>
                   Go Back to Image
                 </a>
               </Button>

--- a/src/app/images/[name]/page.tsx
+++ b/src/app/images/[name]/page.tsx
@@ -590,7 +590,7 @@ export default function ImageDetailsPage() {
   // Handle scan row click
   function handleScanClick(row: any) {
     if (imageData?.name && row.scanId) {
-      window.location.href = `/image/${encodeURIComponent(imageData.name)}/${row.scanId}`;
+      window.location.href = `/images/${encodeURIComponent(imageData.name)}/${row.scanId}`;
     }
   }
 

--- a/src/app/images/page.tsx
+++ b/src/app/images/page.tsx
@@ -182,7 +182,7 @@ export default function ImageRepositoryPage() {
   }
 
   function handleRowClick(row: any) {
-    router.push(`/image/${encodeURIComponent(row.imageName)}`)
+    router.push(`/images/${encodeURIComponent(row.imageName)}`)
   }
 
   function getContextMenuItems(row: any): ContextMenuItem<any>[] {

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -449,7 +449,7 @@ export default function LibraryHomePage() {
             const firstImage = row.affectedImages[0];
             if (firstImage) {
               const imageName = firstImage.imageName.split(':')[0];
-              router.push(`/image/${encodeURIComponent(imageName)}`);
+              router.push(`/images/${encodeURIComponent(imageName)}`);
             }
           },
           label: (value: any) => value?.length > 0 ? `${value.length} images` : 'None',
@@ -466,7 +466,7 @@ export default function LibraryHomePage() {
             const firstFp = row.falsePositiveImages[0];
             if (firstFp) {
               const imageName = firstFp.split(':')[0];
-              router.push(`/image/${encodeURIComponent(imageName)}`);
+              router.push(`/images/${encodeURIComponent(imageName)}`);
             }
           },
           label: (value: any) => value?.length > 0 ? `${value.length} FPs` : 'None',

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -303,7 +303,7 @@ export default function Page() {
 
   // Handle row click
   function handleRowClick(row: any) {
-    router.push(`/image/${encodeURIComponent(row.imageName)}`)
+    router.push(`/images/${encodeURIComponent(row.imageName)}`)
   }
 
   // Get context menu items

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -31,8 +31,8 @@ const data = {
       icon: IconDashboard,
     },
     {
-      title: "Image",
-      url: "/image",
+      title: "Images",
+      url: "/images",
       icon: IconDatabase,
     },
     {

--- a/src/components/vulnerability-details-modal.tsx
+++ b/src/components/vulnerability-details-modal.tsx
@@ -277,7 +277,7 @@ export function VulnerabilityDetailsModal({
                               variant="ghost"
                               size="sm"
                               onClick={() => {
-                                window.open(`/image/${encodeURIComponent(image.imageName.split(':')[0])}`, "_blank");
+                                window.open(`/images/${encodeURIComponent(image.imageName.split(':')[0])}`, "_blank");
                               }}
                             >
                               View Details
@@ -307,7 +307,7 @@ export function VulnerabilityDetailsModal({
                               variant="ghost"
                               size="sm"
                               onClick={() => {
-                                window.open(`/image/${encodeURIComponent(image.imageName.split(':')[0])}`, "_blank");
+                                window.open(`/images/${encodeURIComponent(image.imageName.split(':')[0])}`, "_blank");
                               }}
                             >
                               View Details

--- a/src/components/vulnerability-scatterplot.tsx
+++ b/src/components/vulnerability-scatterplot.tsx
@@ -247,7 +247,7 @@ export function VulnerabilityScatterplot() {
   }, [filteredChartData])
 
   const handlePointClick = React.useCallback((data: LibraryVulnerability) => {
-    router.push(`/image/${encodeURIComponent(data.library)}`)
+    router.push(`/images/${encodeURIComponent(data.library)}`)
   }, [router])
 
   const CustomTooltip = React.useCallback(({ active, payload }: any) => {

--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -379,7 +379,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
       action: {
         label: "View Results",
         onClick: () => {
-          router.push(`/image/${encodeURIComponent(imageName)}/${scanId}`);
+          router.push(`/images/${encodeURIComponent(imageName)}/${scanId}`);
         }
       }
     });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,7 +8,7 @@ const LOGGED_ROUTES = [
   '/repository',
   '/scan-setup',
   '/audit-logs',
-  '/image/',
+  '/images/',
   '/bulk-scan/',
   '/library/',
   '/schedules/',


### PR DESCRIPTION
## Summary
- Renamed /app/image folder to /app/images for better REST naming convention
- Updated sidebar navigation to show "Images" with /images route
- Updated all internal links throughout the application to use /images instead of /image

## Test plan
- [ ] Build completes successfully
- [ ] Navigate to Images page via sidebar
- [ ] Click on an image to view details
- [ ] Navigate to scan results from image details
- [ ] Verify all internal links work correctly
- [ ] Check that vulnerability modal links work
- [ ] Verify breadcrumbs show correct paths