### PR TITLE
Fix skopeo copy credentials flags

### DIFF
--- a/src/lib/registry/providers/generic/GenericOCIProvider.ts
+++ b/src/lib/registry/providers/generic/GenericOCIProvider.ts
@@ -52,7 +52,11 @@ export class GenericOCIProvider extends EnhancedRegistryProvider {
   }
   
   async getSkopeoAuthArgs(): Promise<string> {
-    return `--creds ${this.config.username}:${this.config.password}`;
+    if (!this.config.username || !this.config.password) {
+      return '';
+    }
+    // Properly quote credentials to handle special characters
+    return `--creds "${this.config.username}:${this.config.password}"`;
   }
   
   private getRegistryUrl(): string {

--- a/src/lib/registry/providers/gitlab/GitLabRegistryHandler.ts
+++ b/src/lib/registry/providers/gitlab/GitLabRegistryHandler.ts
@@ -205,11 +205,14 @@ export class GitLabRegistryHandler extends EnhancedRegistryProvider {
   async getSkopeoAuthArgs(): Promise<string> {
     // For GitLab Registry V2, we use basic auth with username/password
     // The registry will handle JWT token exchange internally
+    if (!this.config.username || !this.config.password) {
+      return '';
+    }
     const escapedUsername = this.config.username.replace(/"/g, '\\"');
     const escapedPassword = this.config.password.replace(/"/g, '\\"');
-    
-    const tlsVerify = this.config.skipTlsVerify ? '--tls-verify=false' : '';
-    return `--creds "${escapedUsername}:${escapedPassword}" ${tlsVerify}`.trim();
+
+    // Note: TLS verification should be handled separately by the caller
+    return `--creds "${escapedUsername}:${escapedPassword}"`;
   }
   
   /**

--- a/src/lib/registry/providers/nexus/NexusProvider.ts
+++ b/src/lib/registry/providers/nexus/NexusProvider.ts
@@ -77,7 +77,11 @@ export class NexusProvider extends EnhancedRegistryProvider {
   }
 
   async getSkopeoAuthArgs(): Promise<string> {
-    return `--creds ${this.config.username}:${this.config.password}`;
+    if (!this.config.username || !this.config.password) {
+      return '';
+    }
+    // Properly quote credentials to handle special characters
+    return `--creds "${this.config.username}:${this.config.password}"`;
   }
 
   private getRegistryUrl(): string {


### PR DESCRIPTION
## Summary

Fixes the "unknown flag: --creds" error when copying images between registries using skopeo.

## Changes

- Updated `copyImage` method to use `--src-creds` and `--dest-creds` instead of `--creds`
- Added `shouldVerifyTLSForRegistry` helper method for source registry TLS verification
- Added proper credential quoting in GenericOCIProvider and NexusProvider
- Removed TLS flag from GitLab getSkopeoAuthArgs (now handled separately by caller)
- Added optional sourceCredentials parameter to copyImage method
- Split TLS verification into separate `--src-tls-verify` and `--dest-tls-verify` flags

## Technical Details

The skopeo copy command requires different flags than skopeo inspect:
- skopeo inspect uses: `--creds "user:pass"`
- skopeo copy uses: `--src-creds "user:pass"` and `--dest-creds "user:pass"`

This fix maintains backward compatibility by keeping getSkopeoAuthArgs returning `--creds` format (used by inspect, list-tags), and converts it to the appropriate format in copyImage.

## Testing

- Built and tested with local registry:2 container with credentials
- Successfully copied alpine image from Docker Hub to local registry
- Build passes without errors
- TypeScript compilation successful

## Files Changed

- src/lib/registry/providers/base/EnhancedRegistryProvider.ts
- src/lib/registry/providers/generic/GenericOCIProvider.ts
- src/lib/registry/providers/gitlab/GitLabRegistryHandler.ts
- src/lib/registry/providers/nexus/NexusProvider.ts