### PR TITLE
Optimize vulnerabilities API with PostgreSQL indexes and backend pagination

### DIFF
--- a/prisma/migrations/20251004191157_add_vulnerability_indexes/migration.sql
+++ b/prisma/migrations/20251004191157_add_vulnerability_indexes/migration.sql
@@ -1,0 +1,35 @@
+-- Add performance indexes for vulnerabilities API query optimization
+
+-- Enable pg_trgm extension for efficient ILIKE searches (if not already enabled)
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- Composite index for CVE aggregation and grouping
+-- This helps with GROUP BY cveId and ORDER BY severity, cvssScore
+CREATE INDEX IF NOT EXISTS "scan_vulnerability_findings_cve_severity_cvss_idx"
+ON "public"."scan_vulnerability_findings"("cveId", severity DESC, "cvssScore" DESC NULLS LAST);
+
+-- Composite index for COUNT(DISTINCT scanId) per CVE
+CREATE INDEX IF NOT EXISTS "scan_vulnerability_findings_cve_scan_idx"
+ON "public"."scan_vulnerability_findings"("cveId", "scanId");
+
+-- Covering index for search queries with severity filter
+CREATE INDEX IF NOT EXISTS "scan_vulnerability_findings_severity_cover_idx"
+ON "public"."scan_vulnerability_findings"(severity, "cveId", "cvssScore" DESC, "packageName");
+
+-- GIN indexes for efficient ILIKE text search using trigram matching
+CREATE INDEX IF NOT EXISTS "scan_vulnerability_findings_cveid_trgm_idx"
+ON "public"."scan_vulnerability_findings" USING GIN ("cveId" gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS "scan_vulnerability_findings_packagename_trgm_idx"
+ON "public"."scan_vulnerability_findings" USING GIN ("packageName" gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS "scan_vulnerability_findings_description_trgm_idx"
+ON "public"."scan_vulnerability_findings" USING GIN (description gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS "scan_vulnerability_findings_title_trgm_idx"
+ON "public"."scan_vulnerability_findings" USING GIN (title gin_trgm_ops);
+
+-- Composite index for combined severity + search scenarios
+-- This helps when filtering by severity AND searching
+CREATE INDEX IF NOT EXISTS "scan_vulnerability_findings_severity_cve_idx"
+ON "public"."scan_vulnerability_findings"(severity, "cveId", "cvssScore" DESC);


### PR DESCRIPTION
## Summary
Implements database-level optimizations and true backend pagination for the vulnerabilities API to improve query performance and scalability.

## Database Optimizations

### New Indexes
- Composite index on `(cveId, severity DESC, cvssScore DESC)` - Optimizes GROUP BY and ORDER BY operations
- Composite index on `(cveId, scanId)` - Speeds up COUNT DISTINCT aggregation
- Covering index on `(severity, cveId, cvssScore DESC, packageName)` - Supports filtered queries
- GIN trigram indexes on `cveId`, `packageName`, `description`, `title` - Enables fast ILIKE text searches
- Enabled `pg_trgm` extension for trigram matching

### Query Rewrite
- Changed from ROW_NUMBER() window functions to direct GROUP BY aggregation
- Replaced self-join with DISTINCT ON for finding top severity per CVE
- Added explicit type casting for PostgreSQL Severity enum to text
- Reduced intermediate result sets and table scans

## Backend Pagination

### API Changes
- Implemented true offset/limit pagination at database level
- Returns total count, current offset, limit, and hasMore flag
- Supports combined filtering (severity + search)
- Proper handling of 414 total vulnerabilities

### Frontend Integration
- Server-side pagination with 50 items per page
- Automatic page reset when filters or search terms change
- Integrated with UnifiedTable serverPagination prop
- Displays total count and page navigation controls

## Testing

Verified functionality:
- Basic pagination across multiple pages (different CVEs per page)
- Severity filtering (CRITICAL: 7, HIGH: 50, MEDIUM: 105)
- Text search with ILIKE pattern matching
- Combined filters (severity + search)
- Pagination metadata (total, offset, limit, hasMore)

## Performance Impact

- Significant reduction in query execution time through index utilization
- Efficient pagination without loading all records into memory
- Scalable to large datasets with proper offset/limit handling
- Fast text searches using GIN trigram indexes

## Migration
Run database migration to apply indexes:
```bash
npm run db:migrate
```