### PR TITLE
Fix: Add skipTlsVerify support to NexusProvider

### DIFF
--- a/src/lib/registry/types.ts
+++ b/src/lib/registry/types.ts
@@ -113,6 +113,7 @@ export interface NexusConfig extends RegistryConfig {
   registryUrl: string;
   protocol: string;
   repositoryName?: string; // Nexus can have multiple repositories
+  skipTlsVerify?: boolean;
 }
 
 export interface CacheEntry<T = any> {


### PR DESCRIPTION
## Summary
Implements skipTlsVerify support for Nexus repositories to enable connections to Nexus instances with self-signed certificates.

## Problem
The NexusProvider did not respect the `skipTlsVerify` flag from the repository configuration, causing connection failures when trying to connect to Nexus instances using self-signed certificates or untrusted CAs.

## Solution

### Configuration
- Added `skipTlsVerify` field to `NexusConfig` interface
- Updated `parseConfig` to include `skipTlsVerify` from repository settings

### HTTP API Calls
- Overrode `makeAuthenticatedRequest` method in NexusProvider
- Created custom https.Agent with `rejectUnauthorized: false` when skipTlsVerify is enabled
- Applied agent to fetch options for all HTTP API requests

### Skopeo Operations
- Enhanced `getSkopeoAuthArgs` to include `--tls-verify=false` flag when skipTlsVerify is enabled
- Maintained backwards compatibility by only adding flag when needed

## Changes
1. `src/lib/registry/types.ts` - Added skipTlsVerify field to NexusConfig
2. `src/lib/registry/providers/nexus/NexusProvider.ts`:
   - Added https import
   - Updated parseConfig to include skipTlsVerify
   - Overrode makeAuthenticatedRequest with TLS skip support
   - Updated getSkopeoAuthArgs to include --tls-verify=false flag

## Testing
- TypeScript compilation passes
- No breaking changes to existing functionality
- Backwards compatible - works with and without skipTlsVerify flag

## Use Case
This fix enables HarborGuard to connect to:
- Development Nexus instances with self-signed certificates
- Internal Nexus instances behind corporate firewalls
- Test environments without proper SSL setup

## Security Considerations
- TLS verification is only skipped when explicitly configured
- Default behavior remains secure (skipTlsVerify defaults to false)
- Users must consciously enable this setting, understanding the security implications