### PR TITLE
feat: add Docker registry port configuration for Nexus repositories

### DIFF
--- a/src/app/api/repositories/route.ts
+++ b/src/app/api/repositories/route.ts
@@ -20,7 +20,7 @@ export async function GET() {
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
-    const { name, type, registryUrl, username, password, organization, protocol, skipTlsVerify, testConnection = true } = body
+    const { name, type, registryUrl, username, password, organization, protocol, skipTlsVerify, registryPort, testConnection = true } = body
 
     if (!name || !type || !username || !password) {
       return NextResponse.json(
@@ -38,6 +38,7 @@ export async function POST(request: NextRequest) {
       organization,
       protocol,
       skipTlsVerify,
+      registryPort,
       testConnection
     })
 

--- a/src/components/add-repository-dialog.tsx
+++ b/src/components/add-repository-dialog.tsx
@@ -368,18 +368,33 @@ export function AddRepositoryDialog({ open, onOpenChange, onRepositoryAdded }: A
             )}
 
             {config.type === 'nexus' && (
-              <div className="space-y-2">
-                <Label htmlFor="organization">Repository Name (optional)</Label>
-                <Input
-                  id="organization"
-                  value={config.organization}
-                  onChange={(e) => setConfig(prev => ({ ...prev, organization: e.target.value }))}
-                  placeholder="docker-hosted"
-                />
-                <p className="text-xs text-muted-foreground">
-                  Nexus repository name (default: docker-hosted)
-                </p>
-              </div>
+              <>
+                <div className="space-y-2">
+                  <Label htmlFor="organization">Repository Name (optional)</Label>
+                  <Input
+                    id="organization"
+                    value={config.organization}
+                    onChange={(e) => setConfig(prev => ({ ...prev, organization: e.target.value }))}
+                    placeholder="docker-hosted"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Nexus repository name (default: docker-hosted)
+                  </p>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="registryPort">Docker Registry Port (optional)</Label>
+                  <Input
+                    id="registryPort"
+                    type="number"
+                    value={config.registryPort || ''}
+                    onChange={(e) => setConfig(prev => ({ ...prev, registryPort: e.target.value ? parseInt(e.target.value) : undefined }))}
+                    placeholder="5000"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Port for Docker push/pull operations (default: 5000)
+                  </p>
+                </div>
+              </>
             )}
 
             {config.type === 'gitlab' && (

--- a/src/lib/registry/RegistryService.ts
+++ b/src/lib/registry/RegistryService.ts
@@ -225,6 +225,7 @@ export class RegistryService {
     organization?: string;
     protocol?: string;
     skipTlsVerify?: boolean;
+    registryPort?: number;
     testConnection?: boolean;
   }): Promise<{ repository: Repository; testResult?: ConnectionTestResult }> {
     const { testConnection = true, ...repositoryData } = data;
@@ -272,7 +273,7 @@ export class RegistryService {
       authUrl: null,
       groupId: null,
       skipTlsVerify: repositoryData.skipTlsVerify || false,
-      registryPort: null,
+      registryPort: repositoryData.registryPort || null,
       status: 'UNTESTED',
       lastTested: null,
       repositoryCount: null,
@@ -339,6 +340,7 @@ export class RegistryService {
           encryptedPassword: repositoryData.password, // TODO: encrypt
           organization: repositoryData.organization || null,
           skipTlsVerify: repositoryData.skipTlsVerify || false,
+          registryPort: repositoryData.registryPort || null,
           status,
           repositoryCount,
           lastTested
@@ -370,6 +372,7 @@ export class RegistryService {
         encryptedPassword: repositoryData.password, // TODO: encrypt
         organization: repositoryData.organization || null,
         skipTlsVerify: repositoryData.skipTlsVerify || false,
+        registryPort: repositoryData.registryPort || null,
         status,
         repositoryCount,
         lastTested


### PR DESCRIPTION
## Summary
Adds support for configuring a custom Docker registry port for Nexus repositories, enabling HarborGuard to work with Nexus instances that expose their Docker registry on non-standard ports.

## Problem
Nexus Repository Manager typically uses:
- Port 8081 for the main Nexus API
- Port 5000 (default) for Docker registry operations

However, many deployments use custom ports for the Docker registry (e.g., port 5443 for HTTPS). Previously, HarborGuard always defaulted to port 5000 for Docker operations, making it incompatible with custom port configurations.

## Solution
Added an optional `registryPort` field that allows users to specify the port used for Docker push/pull operations, separate from the main Nexus API port.

## Changes

### Backend
- **`src/lib/registry/RegistryService.ts`**: Added `registryPort` parameter to `createRepository()` method
- **`src/app/api/repositories/route.ts`**: Added `registryPort` to request body extraction
- **`src/lib/registry/providers/nexus/NexusProvider.ts`**: Updated `getDockerRegistryUrl()` to use `registryPort` when configured

### Frontend
- **`src/components/add-repository-dialog.tsx`**: Added optional "Docker Registry Port" input field for Nexus configuration

### Logic Flow
```typescript
private getDockerRegistryUrl(): string {
  let url = this.config.registryUrl;
  url = url.replace(/^https?:\/\//, '');

  if (this.repository.registryPort) {
    // Use configured Docker registry port
    url = url.replace(/:\d+$/, `:${this.repository.registryPort}`);
  } else {
    // Default to port 5000
    url = url.replace(/:\d+$/, ':5000');
  }

  return url;
}
```

## Usage

When adding a Nexus repository:
1. Set **Registry URL** to the Nexus API endpoint (e.g., `172.22.122.96:8081`)
2. Optionally set **Docker Registry Port** to the port used for Docker operations (e.g., `5443`)

All Docker operations (pull, push, scan, export) will use the configured port.

## Testing
Verified with:
- Nexus instance at `172.22.122.96:8081` (API)
- Docker registry on port `5443` (custom HTTPS port)
- Image pull: `skopeo copy docker://172.22.122.96:5443/nginx:latest ...`
- Scan operations successfully connect to correct port
- Export operations push to correct port

## Impact
This change affects:
- **Image scanning from Nexus** (`ScanExecutor.executeRegistryScan()`)
- **Image export to Nexus** (`/api/images/export-to-registry`)
- **Image rescan operations** (`/api/scans/rescan`)

All operations now use the configured `registryPort` instead of hardcoded port 5000.

## Backward Compatibility
✅ Fully backward compatible
- `registryPort` is optional (nullable)
- Defaults to port 5000 when not specified
- Existing repositories continue to work without changes