### PR TITLE
Add repository name fallback for Nexus Skopeo operations

### DIFF
--- a/src/lib/registry/providers/nexus/NexusProvider.ts
+++ b/src/lib/registry/providers/nexus/NexusProvider.ts
@@ -459,9 +459,9 @@ export class NexusProvider extends EnhancedRegistryProvider {
     } catch (error) {
       logger.debug(`[Nexus] First attempt failed, trying with repository name: ${this.config.repositoryName}`);
 
-      // Second attempt: try with repository name prefix
-      const registryUrl = this.getDockerRegistryUrl();
-      const imageRefWithRepo = `${registryUrl}/${this.config.repositoryName}/${image}:${tag || 'latest'}`;
+      // Second attempt: try with repository name prefix using the host port
+      const hostUrl = this.config.registryUrl.replace(/^https?:\/\//, '');
+      const imageRefWithRepo = `${hostUrl}/${this.config.repositoryName}/${image}:${tag || 'latest'}`;
       const fallbackCommand = `skopeo inspect ${authArgs} ${tlsVerify} docker://${imageRefWithRepo}`;
 
       logger.debug(`[Nexus] Attempting with repository name: ${imageRefWithRepo}`);
@@ -514,9 +514,9 @@ export class NexusProvider extends EnhancedRegistryProvider {
     } catch (error) {
       logger.debug(`[Nexus] First attempt failed, trying with repository name: ${this.config.repositoryName}`);
 
-      // Second attempt: try with repository name prefix
-      const registryUrl = this.getDockerRegistryUrl();
-      const imageRefWithRepo = `${registryUrl}/${this.config.repositoryName}/${image}:${tag || 'latest'}`;
+      // Second attempt: try with repository name prefix using the host port
+      const hostUrl = this.config.registryUrl.replace(/^https?:\/\//, '');
+      const imageRefWithRepo = `${hostUrl}/${this.config.repositoryName}/${image}:${tag || 'latest'}`;
       const fallbackCommand = `skopeo copy ${srcAuthArgs} ${tlsVerify} docker://${imageRefWithRepo} docker-archive:${destination}`;
 
       logger.info(`[Nexus] Attempting with repository name: ${imageRefWithRepo}`);
@@ -544,9 +544,9 @@ export class NexusProvider extends EnhancedRegistryProvider {
     } catch (error) {
       logger.debug(`[Nexus] First attempt failed, trying with repository name: ${this.config.repositoryName}`);
 
-      // Second attempt: try with repository name prefix
-      const registryUrl = this.getDockerRegistryUrl();
-      const imageRefWithRepo = `${registryUrl}/${this.config.repositoryName}/${image}:${tag || 'latest'}`;
+      // Second attempt: try with repository name prefix using the host port
+      const hostUrl = this.config.registryUrl.replace(/^https?:\/\//, '');
+      const imageRefWithRepo = `${hostUrl}/${this.config.repositoryName}/${image}:${tag || 'latest'}`;
       const fallbackCommand = `skopeo copy ${destAuthArgs} ${tlsVerify} docker-archive:${source} docker://${imageRefWithRepo}`;
 
       logger.info(`[Nexus] Attempting with repository name: ${imageRefWithRepo}`);

--- a/src/lib/registry/providers/nexus/NexusProvider.ts
+++ b/src/lib/registry/providers/nexus/NexusProvider.ts
@@ -459,9 +459,9 @@ export class NexusProvider extends EnhancedRegistryProvider {
     } catch (error) {
       logger.debug(`[Nexus] First attempt failed, trying with repository name: ${this.config.repositoryName}`);
 
-      // Second attempt: try with repository name prefix using the host port
-      const hostUrl = this.config.registryUrl.replace(/^https?:\/\//, '');
-      const imageRefWithRepo = `${hostUrl}/${this.config.repositoryName}/${image}:${tag || 'latest'}`;
+      // Second attempt: try with repository name prefix using the Docker registry port
+      const registryUrl = this.getDockerRegistryUrl();
+      const imageRefWithRepo = `${registryUrl}/${this.config.repositoryName}/${image}:${tag || 'latest'}`;
       const fallbackCommand = `skopeo inspect ${authArgs} ${tlsVerify} docker://${imageRefWithRepo}`;
 
       logger.debug(`[Nexus] Attempting with repository name: ${imageRefWithRepo}`);
@@ -514,9 +514,9 @@ export class NexusProvider extends EnhancedRegistryProvider {
     } catch (error) {
       logger.debug(`[Nexus] First attempt failed, trying with repository name: ${this.config.repositoryName}`);
 
-      // Second attempt: try with repository name prefix using the host port
-      const hostUrl = this.config.registryUrl.replace(/^https?:\/\//, '');
-      const imageRefWithRepo = `${hostUrl}/${this.config.repositoryName}/${image}:${tag || 'latest'}`;
+      // Second attempt: try with repository name prefix using the Docker registry port
+      const registryUrl = this.getDockerRegistryUrl();
+      const imageRefWithRepo = `${registryUrl}/${this.config.repositoryName}/${image}:${tag || 'latest'}`;
       const fallbackCommand = `skopeo copy ${srcAuthArgs} ${tlsVerify} docker://${imageRefWithRepo} docker-archive:${destination}`;
 
       logger.info(`[Nexus] Attempting with repository name: ${imageRefWithRepo}`);
@@ -544,9 +544,9 @@ export class NexusProvider extends EnhancedRegistryProvider {
     } catch (error) {
       logger.debug(`[Nexus] First attempt failed, trying with repository name: ${this.config.repositoryName}`);
 
-      // Second attempt: try with repository name prefix using the host port
-      const hostUrl = this.config.registryUrl.replace(/^https?:\/\//, '');
-      const imageRefWithRepo = `${hostUrl}/${this.config.repositoryName}/${image}:${tag || 'latest'}`;
+      // Second attempt: try with repository name prefix using the Docker registry port
+      const registryUrl = this.getDockerRegistryUrl();
+      const imageRefWithRepo = `${registryUrl}/${this.config.repositoryName}/${image}:${tag || 'latest'}`;
       const fallbackCommand = `skopeo copy ${destAuthArgs} ${tlsVerify} docker-archive:${source} docker://${imageRefWithRepo}`;
 
       logger.info(`[Nexus] Attempting with repository name: ${imageRefWithRepo}`);


### PR DESCRIPTION
## Summary
Implements fallback logic in NexusProvider for Skopeo operations (inspect, pull, push) to handle different Nexus Docker registry configurations.

## Changes
- Override `inspectImage()`, `pullImage()`, and `pushImage()` methods in NexusProvider
- Implement two-tier fallback pattern:
  1. First attempt: `{host}:{dockerPort}/{image}:{tag}`
  2. Fallback attempt: `{host}:{dockerPort}/{repositoryName}/{image}:{tag}`

## Behavior
When Skopeo operations fail on the first attempt, the provider automatically retries using the repository name prefix. This handles Nexus configurations where some require the repository name in the image path while others don't.

## Requirements
For this to work properly, Nexus must have:
- A configured HTTP/HTTPS Docker connector (not just path-based routing on the API port)
- The `registryPort` field set to the actual Docker registry port in HarborGuard

## Test Plan
- Test with Nexus using port-based Docker connectors
- Verify fallback logic triggers on first failure
- Confirm successful image operations on second attempt