### PR TITLE
feat: Add Docker Swarm services support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,10 @@ next-env.d.ts
 /.claude
 /docs
 
+# Speckit
+/.specify
+/specs
+
 # PostgreSQL data directory
 /var/lib/postgresql/data
 

--- a/src/app/api/docker/info/route.ts
+++ b/src/app/api/docker/info/route.ts
@@ -1,16 +1,21 @@
 import { NextResponse } from 'next/server';
-import { checkDockerAccess } from '@/lib/docker';
+import { checkDockerAccess, getSwarmInfo } from '@/lib/docker';
 
 export async function GET() {
   try {
     const dockerInfo = await checkDockerAccess();
-    return NextResponse.json(dockerInfo);
+    const swarmInfo = await getSwarmInfo();
+
+    return NextResponse.json({
+      ...dockerInfo,
+      swarm: swarmInfo,
+    });
   } catch (error) {
     console.error('Failed to check Docker access:', error);
     return NextResponse.json(
-      { 
-        hasAccess: false, 
-        error: error instanceof Error ? error.message : 'Unknown error' 
+      {
+        hasAccess: false,
+        error: error instanceof Error ? error.message : 'Unknown error'
       },
       { status: 500 }
     );

--- a/src/app/api/docker/services/route.ts
+++ b/src/app/api/docker/services/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server';
+import { getSwarmInfo, listSwarmServices } from '@/lib/docker';
+
+export async function GET() {
+  try {
+    const swarmInfo = await getSwarmInfo();
+
+    if (!swarmInfo.active) {
+      return NextResponse.json({
+        swarmMode: false,
+        message: 'Docker is not running in Swarm mode',
+        services: [],
+      });
+    }
+
+    if (!swarmInfo.isManager) {
+      return NextResponse.json({
+        swarmMode: true,
+        isManager: false,
+        message: 'This node is not a Swarm manager. Service listing requires manager access.',
+        services: [],
+      });
+    }
+
+    const services = await listSwarmServices();
+
+    return NextResponse.json({
+      swarmMode: true,
+      isManager: true,
+      swarmInfo: {
+        ...swarmInfo,
+        services: services.length,
+      },
+      services,
+    });
+  } catch (error) {
+    console.error('Failed to get Swarm services:', error);
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : 'Failed to get Swarm services',
+        swarmMode: false,
+        services: [],
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/new-scan-modal.tsx
+++ b/src/components/new-scan-modal.tsx
@@ -10,6 +10,7 @@ import {
   IconX,
   IconGitBranch,
   IconServer,
+  IconStack2,
 } from "@tabler/icons-react"
 
 import { Badge } from "@/components/ui/badge"
@@ -48,8 +49,10 @@ import { useApp } from "@/contexts/AppContext"
 import { useScanning } from "@/providers/ScanningProvider"
 import { DockerImageAutocomplete } from "@/components/DockerImageAutocomplete"
 import { DockerImageSelector } from "@/components/docker-image-selector"
+import { SwarmServicesList } from "@/components/swarm-services-list"
 import { useDockerImages } from "@/hooks/useDockerImages"
-import type { DockerImage, ScanSource } from "@/types"
+import { useSwarmServices } from "@/hooks/useSwarmServices"
+import type { DockerImage, SwarmService, ScanSource } from "@/types"
 
 
 interface NewScanModalProps {
@@ -61,6 +64,8 @@ export function NewScanModal({ children }: NewScanModalProps) {
   const { state, refreshData } = useApp()
   const { addScanJob } = useScanning()
   const { dockerInfo, images: dockerImages } = useDockerImages()
+  const { isSwarmMode } = useSwarmServices()
+  const [selectedSwarmService, setSelectedSwarmService] = React.useState<SwarmService | null>(null)
   const [isLoading, setIsLoading] = React.useState(false)
   const [isOpen, setIsOpen] = React.useState(false)
   const [scanProgress, setScanProgress] = React.useState(0)
@@ -289,6 +294,8 @@ export function NewScanModal({ children }: NewScanModalProps) {
         return customRegistry
       case 'existing':
         return imageUrl
+      case 'swarm':
+        return selectedSwarmService ? `${selectedSwarmService.image}:${selectedSwarmService.imageTag}` : ''
       case 'private':
         if (selectedRepository) {
           const image = selectedImages[selectedRepository.id]
@@ -374,6 +381,12 @@ export function NewScanModal({ children }: NewScanModalProps) {
         imageName = selectedDockerImage.repository
         imageTag = selectedDockerImage.tag
         registry = 'local' // Set registry to 'local' for local images
+      } else if (selectedSource === 'swarm' && selectedSwarmService) {
+        // Handle Swarm service images - treat as registry images
+        imageName = selectedSwarmService.image
+        imageTag = selectedSwarmService.imageTag
+        // Registry is extracted from the image name if present
+        registry = undefined
       } else if (selectedSource === 'private' && selectedRepository) {
         // Handle private repository images specially to preserve namespace
         const selectedImage = selectedImages[selectedRepository.id]
@@ -429,6 +442,11 @@ export function NewScanModal({ children }: NewScanModalProps) {
         scanRequest.source = 'registry'
         // Note: image name and tag are already set correctly above with namespace preserved
       }
+
+      // For Swarm services, treat as registry images
+      if (selectedSource === 'swarm' && selectedSwarmService) {
+        scanRequest.source = 'registry'
+      }
       
       const response = await fetch('/api/scans/start', {
         method: 'POST',
@@ -469,6 +487,7 @@ export function NewScanModal({ children }: NewScanModalProps) {
       setLocalImageName('')
       setCustomRegistry('')
       setSelectedDockerImage(null)
+      setSelectedSwarmService(null)
       setSearchQuery('')
       setIsOpen(false)
       
@@ -564,7 +583,7 @@ export function NewScanModal({ children }: NewScanModalProps) {
             <h3 className="text-lg font-semibold">Scan New Image</h3>
             
             <Tabs value={selectedSource} onValueChange={setSelectedSource}>
-              <TabsList className={`grid w-full ${dockerInfo?.hasAccess ? 'grid-cols-5' : 'grid-cols-4'}`}>
+              <TabsList className={`grid w-full ${dockerInfo?.hasAccess && isSwarmMode ? 'grid-cols-6' : dockerInfo?.hasAccess ? 'grid-cols-5' : 'grid-cols-4'}`}>
                 <TabsTrigger value="dockerhub" className="flex items-center gap-1">
                   <IconBrandDocker className="h-4 w-4" />
                   <span className="hidden sm:inline">Docker Hub</span>
@@ -577,6 +596,12 @@ export function NewScanModal({ children }: NewScanModalProps) {
                   <TabsTrigger value="local" className="flex items-center gap-1">
                     <IconDeviceDesktop className="h-4 w-4" />
                     <span className="hidden sm:inline">Local</span>
+                  </TabsTrigger>
+                )}
+                {dockerInfo?.hasAccess && isSwarmMode && (
+                  <TabsTrigger value="swarm" className="flex items-center gap-1">
+                    <IconStack2 className="h-4 w-4" />
+                    <span className="hidden sm:inline">Swarm</span>
                   </TabsTrigger>
                 )}
                 <TabsTrigger value="custom" className="flex items-center gap-1">
@@ -672,6 +697,22 @@ export function NewScanModal({ children }: NewScanModalProps) {
                   Enter the full URL to your custom registry image.
                 </p>
               </TabsContent>
+
+              {dockerInfo?.hasAccess && isSwarmMode && (
+                <TabsContent value="swarm" className="space-y-3">
+                  <Label>Select Swarm Service</Label>
+                  <SwarmServicesList
+                    onServiceSelect={(service) => {
+                      setSelectedSwarmService(service)
+                    }}
+                    selectedService={selectedSwarmService}
+                    disabled={isLoading}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Select a service from your Docker Swarm cluster to scan its image.
+                  </p>
+                </TabsContent>
+              )}
 
               <TabsContent value="private" className="space-y-3">
                 {repositories.length === 0 ? (
@@ -981,16 +1022,17 @@ export function NewScanModal({ children }: NewScanModalProps) {
           <DialogClose asChild>
             <Button variant="outline">Cancel</Button>
           </DialogClose>
-          <Button 
+          <Button
             onClick={handleStartScan}
             disabled={
-              isLoading || 
-              !selectedSource || 
+              isLoading ||
+              !selectedSource ||
               (selectedSource === 'dockerhub' && !imageUrl) ||
               (selectedSource === 'github' && !githubRepo) ||
               (selectedSource === 'local' && !scanAllLocalImages && !selectedDockerImage && !localImageName) ||
               (selectedSource === 'custom' && !customRegistry) ||
               (selectedSource === 'existing' && !imageUrl) ||
+              (selectedSource === 'swarm' && !selectedSwarmService) ||
               (selectedSource === 'private' && (!selectedRepository || !selectedImages[selectedRepository?.id] || !selectedTags[selectedRepository?.id]))
             }
           >

--- a/src/components/swarm-services-list.tsx
+++ b/src/components/swarm-services-list.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  IconServer,
+  IconRefresh,
+  IconStack2,
+  IconWorld,
+  IconCopy,
+  IconCheck,
+} from '@tabler/icons-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import { useSwarmServices } from '@/hooks/useSwarmServices';
+import type { SwarmService } from '@/types';
+
+interface SwarmServicesListProps {
+  onServiceSelect?: (service: SwarmService) => void;
+  selectedService?: SwarmService | null;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function SwarmServicesList({
+  onServiceSelect,
+  selectedService,
+  disabled,
+  className
+}: SwarmServicesListProps) {
+  const { services, swarmInfo, isSwarmMode, isManager, loading, error, refetch } = useSwarmServices();
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  const copyImageName = (service: SwarmService, e: React.MouseEvent) => {
+    e.stopPropagation();
+    const fullName = `${service.image}:${service.imageTag}`;
+    navigator.clipboard.writeText(fullName);
+    setCopiedId(service.id);
+    setTimeout(() => setCopiedId(null), 2000);
+  };
+
+  // Not in Swarm mode
+  if (!isSwarmMode) {
+    return (
+      <div className="text-center py-8">
+        <IconStack2 className="mx-auto h-12 w-12 text-muted-foreground" />
+        <h3 className="mt-2 text-sm font-medium">Not in Swarm Mode</h3>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Docker is not running in Swarm mode. Deploy HarborGuard in a Swarm cluster to use this feature.
+        </p>
+      </div>
+    );
+  }
+
+  // Not a manager node
+  if (!isManager) {
+    return (
+      <div className="text-center py-8">
+        <IconWorld className="mx-auto h-12 w-12 text-muted-foreground" />
+        <h3 className="mt-2 text-sm font-medium">Manager Node Required</h3>
+        <p className="mt-1 text-sm text-muted-foreground">
+          This node is a worker. Deploy HarborGuard on a manager node to list Swarm services.
+        </p>
+      </div>
+    );
+  }
+
+  // Loading state
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-primary"></div>
+        <span className="ml-2 text-sm text-muted-foreground">Loading Swarm services...</span>
+      </div>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <div className="bg-destructive/10 border border-destructive/20 rounded-md p-4">
+        <h3 className="text-sm font-medium text-destructive">Error loading Swarm services</h3>
+        <p className="mt-1 text-sm text-destructive/80">{error}</p>
+        <Button onClick={refetch} variant="outline" size="sm" className="mt-2">
+          Try again
+        </Button>
+      </div>
+    );
+  }
+
+  // No services
+  if (services.length === 0) {
+    return (
+      <div className="text-center py-8">
+        <IconServer className="mx-auto h-12 w-12 text-muted-foreground" />
+        <h3 className="mt-2 text-sm font-medium">No Services Found</h3>
+        <p className="mt-1 text-sm text-muted-foreground">
+          No services are currently running in this Swarm cluster.
+        </p>
+        <Button onClick={refetch} variant="outline" size="sm" className="mt-4">
+          <IconRefresh className="h-4 w-4 mr-2" />
+          Refresh
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("space-y-2", className)}>
+      {/* Swarm Info Header */}
+      <div className="flex items-center justify-between mb-4 p-2 bg-muted/50 rounded-md">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <IconStack2 className="h-4 w-4" />
+          <span>
+            Swarm: {swarmInfo?.nodes} node{swarmInfo?.nodes !== 1 ? 's' : ''},
+            {' '}{services.length} service{services.length !== 1 ? 's' : ''}
+          </span>
+        </div>
+        <Button variant="ghost" size="sm" onClick={refetch} disabled={loading}>
+          <IconRefresh className={cn("h-4 w-4", loading && "animate-spin")} />
+        </Button>
+      </div>
+
+      {/* Services List */}
+      <div className="space-y-2 max-h-72 overflow-y-auto">
+        {services.map((service) => (
+          <div
+            key={service.id}
+            className={cn(
+              "p-3 border rounded-md cursor-pointer transition-colors",
+              selectedService?.id === service.id
+                ? "border-primary bg-primary/5"
+                : "hover:bg-muted/50",
+              disabled && "opacity-50 cursor-not-allowed"
+            )}
+            onClick={() => !disabled && onServiceSelect?.(service)}
+          >
+            <div className="flex items-start justify-between">
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="font-medium text-sm truncate">{service.name}</span>
+                  <Badge variant={service.mode === 'global' ? 'secondary' : 'outline'} className="text-xs">
+                    {service.mode}
+                  </Badge>
+                </div>
+
+                <div className="flex items-center gap-2 mt-1">
+                  <code className="text-xs text-muted-foreground bg-muted px-1 py-0.5 rounded">
+                    {service.image}:{service.imageTag}
+                  </code>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-5 w-5 p-0"
+                    onClick={(e) => copyImageName(service, e)}
+                  >
+                    {copiedId === service.id ? (
+                      <IconCheck className="h-3 w-3 text-green-500" />
+                    ) : (
+                      <IconCopy className="h-3 w-3" />
+                    )}
+                  </Button>
+                </div>
+
+                <div className="flex items-center gap-4 mt-2 text-xs text-muted-foreground">
+                  <span>
+                    Replicas: {service.replicas.running}/{service.replicas.desired}
+                  </span>
+                  {service.ports.length > 0 && (
+                    <span>
+                      Ports: {service.ports.map(p => `${p.published}:${p.target}`).join(', ')}
+                    </span>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useSwarmServices.ts
+++ b/src/hooks/useSwarmServices.ts
@@ -1,0 +1,67 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import type { SwarmService, SwarmInfo, SwarmServicesResponse } from '@/types';
+
+interface UseSwarmServicesReturn {
+  services: SwarmService[];
+  swarmInfo: SwarmInfo | null;
+  isSwarmMode: boolean;
+  isManager: boolean;
+  loading: boolean;
+  error: string | null;
+  message: string | null;
+  refetch: () => Promise<void>;
+}
+
+export function useSwarmServices(): UseSwarmServicesReturn {
+  const [services, setServices] = useState<SwarmService[]>([]);
+  const [swarmInfo, setSwarmInfo] = useState<SwarmInfo | null>(null);
+  const [isSwarmMode, setIsSwarmMode] = useState(false);
+  const [isManager, setIsManager] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const fetchServices = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    setMessage(null);
+
+    try {
+      const response = await fetch('/api/docker/services');
+      const data: SwarmServicesResponse = await response.json();
+
+      setIsSwarmMode(data.swarmMode);
+      setIsManager(data.isManager ?? false);
+      setSwarmInfo(data.swarmInfo ?? null);
+      setServices(data.services);
+      setMessage(data.message ?? null);
+
+      if (data.error) {
+        setError(data.error);
+      }
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to fetch Swarm services';
+      setError(errorMessage);
+      setServices([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchServices();
+  }, [fetchServices]);
+
+  return {
+    services,
+    swarmInfo,
+    isSwarmMode,
+    isManager,
+    loading,
+    error,
+    message,
+    refetch: fetchServices,
+  };
+}

--- a/src/lib/docker.ts
+++ b/src/lib/docker.ts
@@ -1,5 +1,6 @@
 import { exec } from 'child_process';
 import { promisify } from 'util';
+import type { SwarmService, SwarmInfo } from '@/types';
 
 const execAsync = promisify(exec);
 
@@ -100,11 +101,104 @@ export async function inspectDockerImage(imageName: string): Promise<any> {
       `docker inspect "${imageName}"`,
       { timeout: 10000 }
     );
-    
+
     const imageData = JSON.parse(stdout);
     return imageData[0]; // docker inspect returns an array
   } catch (error) {
     console.error(`Failed to inspect Docker image ${imageName}:`, error);
     throw new Error(`Failed to inspect Docker image: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+/**
+ * Check if Docker is running in Swarm mode and get cluster info
+ */
+export async function getSwarmInfo(): Promise<SwarmInfo> {
+  try {
+    const { stdout } = await execAsync(
+      'docker info --format "{{.Swarm.LocalNodeState}}\t{{.Swarm.NodeID}}\t{{.Swarm.ControlAvailable}}\t{{.Swarm.Nodes}}\t{{.Swarm.Managers}}"',
+      { timeout: 5000 }
+    );
+
+    const [state, nodeId, isManager, nodes, managers] = stdout.trim().split('\t');
+
+    return {
+      active: state === 'active',
+      nodeId: nodeId || undefined,
+      isManager: isManager === 'true',
+      nodes: parseInt(nodes) || 0,
+      managers: parseInt(managers) || 0,
+    };
+  } catch (error) {
+    console.error('Failed to get Swarm info:', error);
+    return { active: false };
+  }
+}
+
+/**
+ * List all services in the Swarm cluster
+ */
+export async function listSwarmServices(): Promise<SwarmService[]> {
+  try {
+    const { stdout } = await execAsync(
+      `docker service ls --format '{{json .}}'`,
+      { timeout: 10000 }
+    );
+
+    const lines = stdout.trim().split('\n').filter(line => line.length > 0);
+    const services: SwarmService[] = [];
+
+    for (const line of lines) {
+      const svc = JSON.parse(line);
+
+      // Get detailed service info
+      const { stdout: detailStdout } = await execAsync(
+        `docker service inspect ${svc.ID} --format '{{json .}}'`,
+        { timeout: 5000 }
+      );
+      const detail = JSON.parse(detailStdout);
+
+      // Parse image name and tag
+      const fullImage = detail.Spec?.TaskTemplate?.ContainerSpec?.Image || svc.Image;
+      const imageWithoutDigest = fullImage.split('@')[0];
+      const lastColonIndex = imageWithoutDigest.lastIndexOf(':');
+      let image: string;
+      let tag: string;
+
+      if (lastColonIndex > 0 && !imageWithoutDigest.substring(lastColonIndex).includes('/')) {
+        image = imageWithoutDigest.substring(0, lastColonIndex);
+        tag = imageWithoutDigest.substring(lastColonIndex + 1);
+      } else {
+        image = imageWithoutDigest;
+        tag = 'latest';
+      }
+
+      // Parse replicas
+      const [running, desired] = (svc.Replicas || '0/0').split('/').map(Number);
+
+      // Parse ports
+      const ports = (detail.Endpoint?.Ports || []).map((p: any) => ({
+        published: p.PublishedPort,
+        target: p.TargetPort,
+        protocol: p.Protocol,
+      }));
+
+      services.push({
+        id: svc.ID,
+        name: svc.Name,
+        image,
+        imageTag: tag,
+        replicas: { running, desired },
+        mode: svc.Mode === 'global' ? 'global' : 'replicated',
+        ports,
+        createdAt: detail.CreatedAt,
+        updatedAt: detail.UpdatedAt,
+      });
+    }
+
+    return services;
+  } catch (error) {
+    console.error('Failed to list Swarm services:', error);
+    throw new Error(`Failed to list Swarm services: ${error instanceof Error ? error.message : String(error)}`);
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -415,6 +415,45 @@ export interface DockerImage {
 export interface DockerInfo {
   hasAccess: boolean;
   version?: string;
+  swarm?: SwarmInfo;
+  error?: string;
+}
+
+// Docker Swarm Types
+export interface SwarmService {
+  id: string;
+  name: string;
+  image: string;
+  imageTag: string;
+  replicas: {
+    running: number;
+    desired: number;
+  };
+  mode: 'replicated' | 'global';
+  ports: Array<{
+    published: number;
+    target: number;
+    protocol: string;
+  }>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SwarmInfo {
+  active: boolean;
+  nodeId?: string;
+  isManager?: boolean;
+  nodes?: number;
+  managers?: number;
+  services?: number;
+}
+
+export interface SwarmServicesResponse {
+  swarmMode: boolean;
+  isManager?: boolean;
+  swarmInfo?: SwarmInfo;
+  services: SwarmService[];
+  message?: string;
   error?: string;
 }
 


### PR DESCRIPTION
## Summary

- Adds ability to detect Docker Swarm mode and list services for vulnerability scanning
- Addresses GitHub Issue #153 where users running HarborGuard in Docker Swarm cannot see images on other nodes
- New "Swarm" tab in scan modal allows selecting services from the cluster

## Changes

**New files:**
- `src/app/api/docker/services/route.ts` - API endpoint for Swarm services
- `src/hooks/useSwarmServices.ts` - React hook for Swarm state management
- `src/components/swarm-services-list.tsx` - UI component for displaying services

**Modified files:**
- `src/types/index.ts` - Added SwarmService, SwarmInfo, SwarmServicesResponse types
- `src/lib/docker.ts` - Added getSwarmInfo() and listSwarmServices() functions
- `src/app/api/docker/info/route.ts` - Extended to include Swarm status
- `src/components/new-scan-modal.tsx` - Added Swarm Services tab integration

## Features

- **Swarm Mode Detection**: Automatically detects if Docker is in Swarm mode
- **Service Listing**: Lists all Swarm services with image, replicas, ports, and mode
- **Scan Integration**: Users can select a Swarm service and initiate vulnerability scans
- **Cluster Info**: Displays node count and service count in the UI
- **Error Handling**: Appropriate messages for non-Swarm and worker node scenarios

## Test plan

- [ ] Deploy HarborGuard on a Swarm manager node
- [ ] Verify "Swarm" tab appears in New Scan modal
- [ ] Confirm all Swarm services are listed with correct details
- [ ] Select a service and verify scan initiates successfully
- [ ] Test on non-Swarm Docker to verify tab is hidden
- [ ] Test on worker node to verify appropriate message is shown