### PR TITLE
feat: integrate Go sensor rewrite

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,5 @@ docs
 .specify
 specs
 coverage
-harborguard-sensor/node_modules
-harborguard-sensor/dist
 harborguard-sensor/.git
+harborguard-sensor/harborguard-sensor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ---- 0) Build sensor module (Go) ----
-FROM golang:1.23-alpine AS sensor-builder
+FROM golang:1.24-alpine AS sensor-builder
 WORKDIR /sensor
 COPY harborguard-sensor/go.mod harborguard-sensor/go.sum ./
 RUN go mod download

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-# ---- 0) Build sensor module ----
-FROM node:20-alpine AS sensor-builder
+# ---- 0) Build sensor module (Go) ----
+FROM golang:1.23-alpine AS sensor-builder
 WORKDIR /sensor
-COPY harborguard-sensor/package.json harborguard-sensor/package-lock.json* ./
-RUN npm ci
+COPY harborguard-sensor/go.mod harborguard-sensor/go.sum ./
+RUN go mod download
 COPY harborguard-sensor/ .
-RUN npm run build
+RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /harborguard-sensor .
 
 # ---- 1) Build Next.js ----
 FROM node:20-alpine AS builder
@@ -141,10 +141,8 @@ COPY --from=builder /app/prisma ./prisma
 COPY --from=builder /app/src/generated ./src/generated
 COPY --from=builder /app/scripts ./scripts
 
-# Sensor module (CLI: node /app/sensor/dist/index.js)
-COPY --from=sensor-builder /sensor/dist ./sensor/dist
-COPY --from=sensor-builder /sensor/node_modules ./sensor/node_modules
-COPY --from=sensor-builder /sensor/package.json ./sensor/package.json
+# Sensor binary (Go)
+COPY --from=sensor-builder /harborguard-sensor ./sensor/harborguard-sensor
 
 ENV PORT=3000
 

--- a/src/lib/scanner/SensorBridge.ts
+++ b/src/lib/scanner/SensorBridge.ts
@@ -15,7 +15,7 @@ import { mapSeverityToEnum } from '@/lib/utils/severity-utils';
 
 const execFileAsync = promisify(execFile);
 
-const SENSOR_CLI = process.env.SENSOR_CLI_PATH || '/app/sensor/dist/index.js';
+const SENSOR_CLI = process.env.SENSOR_CLI_PATH || '/app/sensor/harborguard-sensor';
 
 interface ScanEnvelope {
   version: string;
@@ -102,10 +102,10 @@ export async function executeScanViaSensor(
   }
 
   onProgress?.(30, 'Running sensor scan');
-  logger.info(`[SensorBridge] Executing: node ${SENSOR_CLI} ${args.join(' ')}`);
+  logger.info(`[SensorBridge] Executing: ${SENSOR_CLI} ${args.join(' ')}`);
 
   try {
-    const { stdout, stderr } = await execFileAsync('node', [SENSOR_CLI, ...args], {
+    const { stdout, stderr } = await execFileAsync(SENSOR_CLI, args, {
       timeout: 30 * 60 * 1000,
       maxBuffer: 100 * 1024 * 1024,
       env: { ...process.env },


### PR DESCRIPTION
## Summary
- Update monolith Dockerfile to build sensor with Go instead of Node.js
- Update SensorBridge.ts to call Go binary directly (`execFileAsync(SENSOR_CLI, args)` instead of `execFileAsync('node', [SENSOR_CLI, ...args])`)
- Update submodule pointer to Go rewrite branch
- Update .dockerignore for Go binary

## Test plan
- [ ] Monolith `docker build` succeeds with Go sensor builder stage
- [ ] Local-sensor mode: scan via SensorBridge produces valid ScanEnvelope
- [ ] Agent-dispatch mode: sensor container picks up jobs and uploads results