### PR TITLE
Dashboard scaling fixes: pool tuning, PDF limit, cleanup, S3 retention

### DIFF
--- a/docker-compose.distributed.yml
+++ b/docker-compose.distributed.yml
@@ -9,7 +9,7 @@ services:
       - NODE_ENV=production
       - PORT=3000
       - HOSTNAME=0.0.0.0
-      - DATABASE_URL=postgresql://postgres:harborguard@db:5432/harborguard
+      - DATABASE_URL=postgresql://postgres:harborguard@db:5432/harborguard?connection_limit=25&pool_timeout=30
       - S3_ENDPOINT=http://minio:9000
       - S3_BUCKET=harborguard
       - S3_ACCESS_KEY=minioadmin
@@ -24,6 +24,9 @@ services:
 
   sensor:
     image: ghcr.io/harborguard/harborguard-sensor:latest
+    # Scale: docker compose up --scale sensor=3
+    deploy:
+      replicas: 1
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - sensor-cache:/workspace/cache

--- a/src/app/api/images/name/[name]/scan/[scanId]/pdf-report/route.ts
+++ b/src/app/api/images/name/[name]/scan/[scanId]/pdf-report/route.ts
@@ -4,6 +4,9 @@ import puppeteer from 'puppeteer'
 import { apiError } from '@/lib/api/api-utils'
 import { loadScannerDataFromS3 } from '@/lib/storage/s3'
 
+let activePdfRenders = 0;
+const MAX_CONCURRENT_PDFS = 2;
+
 function generateHtmlReport(scan: any, decodedImageName: string, scannerData: Record<string, any>): string {
   const metadata = scan.metadata
 
@@ -595,6 +598,14 @@ export async function GET(
   _request: NextRequest,
   { params }: { params: Promise<{ name: string; scanId: string }> }
 ) {
+  if (activePdfRenders >= MAX_CONCURRENT_PDFS) {
+    return NextResponse.json(
+      { error: 'PDF generation is busy, please try again shortly' },
+      { status: 429, headers: { 'Retry-After': '5' } }
+    );
+  }
+  activePdfRenders++;
+
   let browser
   try {
     const { name, scanId } = await params
@@ -667,5 +678,7 @@ export async function GET(
       await browser.close()
     }
     return apiError(error, 'Failed to generate PDF report');
+  } finally {
+    activePdfRenders--;
   }
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,6 +1,7 @@
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
-    // Only run on the server
+    const { scheduleAutoCleanup } = await import('./lib/cleanup');
+    scheduleAutoCleanup();
     await initializeDemoMode();
   }
 }

--- a/src/lib/cleanup.ts
+++ b/src/lib/cleanup.ts
@@ -6,6 +6,7 @@
 import { config } from './config';
 import { logger } from './logger';
 import { prisma } from './prisma';
+import { DashboardS3Client } from './storage/s3';
 import fs from 'fs/promises';
 import path from 'path';
 
@@ -42,6 +43,8 @@ export class DatabaseCleanup {
             id: true,
             requestId: true,
             reportsDir: true,
+            metadata: { select: { s3Prefix: true } },
+            agentJobs: { select: { id: true }, take: 1 },
           }
         });
 
@@ -59,6 +62,27 @@ export class DatabaseCleanup {
           } catch (error) {
             const errorMessage = error instanceof Error ? error.message : String(error);
             logger.error(`Failed to cleanup report files for scan ${scan.id}:`, errorMessage);
+          }
+        }
+
+        // Clean up S3 artifacts before deleting DB records
+        if (DashboardS3Client.isConfigured()) {
+          try {
+            const s3 = DashboardS3Client.getInstance();
+            for (const scan of batch) {
+              try {
+                const prefix = scan.metadata?.s3Prefix
+                  || (scan.agentJobs?.[0]?.id ? `scans/${scan.agentJobs[0].id}/` : null);
+                if (prefix) {
+                  await s3.deletePrefix(prefix);
+                }
+              } catch (s3Err) {
+                // Non-fatal: S3 failures should not block DB cleanup
+                logger.warn(`Failed to delete S3 artifacts for scan ${scan.id}:`, s3Err);
+              }
+            }
+          } catch (s3InitErr) {
+            logger.warn('Failed to initialize S3 client for cleanup:', s3InitErr);
           }
         }
 
@@ -208,3 +232,11 @@ export class DatabaseCleanup {
 
 // Create singleton instance
 export const databaseCleanup = new DatabaseCleanup();
+
+let cleanupScheduled = false;
+export function scheduleAutoCleanup() {
+  if (cleanupScheduled) return;
+  cleanupScheduled = true;
+  setTimeout(() => databaseCleanup.cleanupOldScans().catch(console.error), 30_000);
+  setInterval(() => databaseCleanup.cleanupOldScans().catch(console.error), 24 * 60 * 60 * 1000);
+}

--- a/src/lib/storage/s3.ts
+++ b/src/lib/storage/s3.ts
@@ -1,4 +1,4 @@
-import { S3Client, GetObjectCommand, HeadObjectCommand } from '@aws-sdk/client-s3';
+import { S3Client, GetObjectCommand, HeadObjectCommand, ListObjectsV2Command, DeleteObjectsCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import type { Readable } from 'stream';
 
@@ -51,6 +51,32 @@ export class DashboardS3Client {
     } catch {
       return false;
     }
+  }
+
+  async deletePrefix(prefix: string): Promise<number> {
+    let deleted = 0;
+    let continuationToken: string | undefined;
+    do {
+      const list = await this.client.send(
+        new ListObjectsV2Command({
+          Bucket: this.bucket,
+          Prefix: prefix,
+          ContinuationToken: continuationToken,
+        }),
+      );
+      const objects = list.Contents;
+      if (!objects || objects.length === 0) break;
+
+      await this.client.send(
+        new DeleteObjectsCommand({
+          Bucket: this.bucket,
+          Delete: { Objects: objects.map((o) => ({ Key: o.Key! })) },
+        }),
+      );
+      deleted += objects.length;
+      continuationToken = list.IsTruncated ? list.NextContinuationToken : undefined;
+    } while (continuationToken);
+    return deleted;
   }
 
   private async getJson(key: string): Promise<any | null> {


### PR DESCRIPTION
## Summary
- Increase Prisma connection pool to 25 with 30s timeout to handle concurrent API requests
- Add PDF generation concurrency semaphore (max 2) returning 429 when busy
- Add sensor deploy.replicas config for horizontal scaling via `docker compose up --scale sensor=3`
- Auto-schedule database cleanup every 24h (30s after server start, then daily)
- Add S3 artifact retention cleanup — delete orphaned raw results/SBOMs when scans expire

## Test plan
- [ ] PDF endpoint returns 429 when 3rd concurrent request arrives
- [ ] `docker compose up --scale sensor=3` registers 3 agents in dashboard
- [ ] Cleanup runs 30s after dashboard start (check logs)
- [ ] Old scan deletion also removes S3 artifacts (check MinIO after cleanup)
- [ ] Connection pool handles 50 concurrent API requests without timeout