### PR TITLE
Add Settings page with data retention controls

### DIFF
--- a/prisma/migrations/20260323000000_add_app_settings/migration.sql
+++ b/prisma/migrations/20260323000000_add_app_settings/migration.sql
@@ -1,0 +1,8 @@
+-- CreateTable
+CREATE TABLE "app_settings" (
+    "key" TEXT NOT NULL,
+    "value" TEXT NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "app_settings_pkey" PRIMARY KEY ("key")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1205,3 +1205,11 @@ enum ScheduledScanTrigger {
   SCHEDULED
   API
 }
+
+model AppSetting {
+  key       String   @id
+  value     String
+  updatedAt DateTime @updatedAt
+
+  @@map("app_settings")
+}

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,0 +1,97 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+const ALLOWED_KEYS: Record<string, { min?: number; max?: number; type: 'number' | 'boolean' }> = {
+  cleanupOldScansDays: { min: 1, max: 365, type: 'number' },
+  cleanupAuditLogsDays: { min: 1, max: 365, type: 'number' },
+  cleanupBulkScansDays: { min: 1, max: 365, type: 'number' },
+  cleanupS3Artifacts: { type: 'boolean' },
+};
+
+const DEFAULTS: Record<string, string> = {
+  cleanupOldScansDays: '30',
+  cleanupAuditLogsDays: '30',
+  cleanupBulkScansDays: '30',
+  cleanupS3Artifacts: 'true',
+};
+
+export async function GET() {
+  try {
+    const rows = await prisma.appSetting.findMany();
+    const settings: Record<string, string> = { ...DEFAULTS };
+    for (const row of rows) {
+      settings[row.key] = row.value;
+    }
+    return NextResponse.json(settings);
+  } catch (error) {
+    console.error('Failed to load settings:', error);
+    return NextResponse.json(DEFAULTS);
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const errors: string[] = [];
+    const updates: { key: string; value: string }[] = [];
+
+    for (const [key, rawValue] of Object.entries(body)) {
+      const rule = ALLOWED_KEYS[key];
+      if (!rule) {
+        errors.push(`Unknown setting: ${key}`);
+        continue;
+      }
+
+      if (rule.type === 'number') {
+        const num = Number(rawValue);
+        if (!Number.isInteger(num)) {
+          errors.push(`${key} must be an integer`);
+          continue;
+        }
+        if (rule.min !== undefined && num < rule.min) {
+          errors.push(`${key} must be at least ${rule.min}`);
+          continue;
+        }
+        if (rule.max !== undefined && num > rule.max) {
+          errors.push(`${key} must be at most ${rule.max}`);
+          continue;
+        }
+        updates.push({ key, value: String(num) });
+      } else if (rule.type === 'boolean') {
+        const val = String(rawValue).toLowerCase();
+        if (val !== 'true' && val !== 'false') {
+          errors.push(`${key} must be true or false`);
+          continue;
+        }
+        updates.push({ key, value: val });
+      }
+    }
+
+    if (errors.length > 0) {
+      return NextResponse.json({ error: errors.join(', ') }, { status: 400 });
+    }
+
+    for (const { key, value } of updates) {
+      await prisma.appSetting.upsert({
+        where: { key },
+        update: { value },
+        create: { key, value },
+      });
+    }
+
+    // Return full settings after update
+    const rows = await prisma.appSetting.findMany();
+    const settings: Record<string, string> = { ...DEFAULTS };
+    for (const row of rows) {
+      settings[row.key] = row.value;
+    }
+
+    return NextResponse.json(settings);
+  } catch (error) {
+    console.error('Failed to update settings:', error);
+    return NextResponse.json(
+      { error: 'Failed to update settings' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import * as React from "react";
+import { toast } from "sonner";
+import { IconSettings, IconTrash, IconDatabase, IconCloud } from "@tabler/icons-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { Badge } from "@/components/ui/badge";
+
+interface Settings {
+  cleanupOldScansDays: string;
+  cleanupAuditLogsDays: string;
+  cleanupBulkScansDays: string;
+  cleanupS3Artifacts: string;
+}
+
+export default function SettingsPage() {
+  const [settings, setSettings] = React.useState<Settings | null>(null);
+  const [saving, setSaving] = React.useState(false);
+  const [dirty, setDirty] = React.useState(false);
+
+  React.useEffect(() => {
+    fetch("/api/settings")
+      .then((r) => r.json())
+      .then((data) => setSettings(data))
+      .catch(() => toast.error("Failed to load settings"));
+  }, []);
+
+  function update(key: keyof Settings, value: string) {
+    if (!settings) return;
+    setSettings({ ...settings, [key]: value });
+    setDirty(true);
+  }
+
+  async function save() {
+    if (!settings) return;
+    setSaving(true);
+    try {
+      const res = await fetch("/api/settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          cleanupOldScansDays: Number(settings.cleanupOldScansDays),
+          cleanupAuditLogsDays: Number(settings.cleanupAuditLogsDays),
+          cleanupBulkScansDays: Number(settings.cleanupBulkScansDays),
+          cleanupS3Artifacts: settings.cleanupS3Artifacts,
+        }),
+      });
+      if (!res.ok) {
+        const err = await res.json();
+        toast.error(err.error || "Failed to save settings");
+        return;
+      }
+      const updated = await res.json();
+      setSettings(updated);
+      setDirty(false);
+      toast.success("Settings saved");
+    } catch {
+      toast.error("Failed to save settings");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (!settings) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <div className="text-muted-foreground">Loading settings...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6 p-6 max-w-3xl">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight flex items-center gap-2">
+            <IconSettings className="size-6" />
+            Settings
+          </h1>
+          <p className="text-muted-foreground text-sm mt-1">
+            Configure data retention and cleanup policies
+          </p>
+        </div>
+        <Button onClick={save} disabled={saving || !dirty}>
+          {saving ? "Saving..." : "Save Changes"}
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <IconDatabase className="size-5" />
+            Scan Retention
+          </CardTitle>
+          <CardDescription>
+            Completed scans older than this threshold are automatically deleted every 24 hours,
+            including associated vulnerability findings, metadata, and report files.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label htmlFor="cleanupOldScansDays">Retention period</Label>
+              <p className="text-xs text-muted-foreground">1 &ndash; 365 days</p>
+            </div>
+            <div className="flex items-center gap-2">
+              <Input
+                id="cleanupOldScansDays"
+                type="number"
+                min={1}
+                max={365}
+                className="w-24 text-right"
+                value={settings.cleanupOldScansDays}
+                onChange={(e) => update("cleanupOldScansDays", e.target.value)}
+              />
+              <span className="text-sm text-muted-foreground">days</span>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <IconTrash className="size-5" />
+            Audit Log Retention
+          </CardTitle>
+          <CardDescription>
+            Audit log entries older than this threshold are purged during the daily cleanup cycle.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label htmlFor="cleanupAuditLogsDays">Retention period</Label>
+              <p className="text-xs text-muted-foreground">1 &ndash; 365 days</p>
+            </div>
+            <div className="flex items-center gap-2">
+              <Input
+                id="cleanupAuditLogsDays"
+                type="number"
+                min={1}
+                max={365}
+                className="w-24 text-right"
+                value={settings.cleanupAuditLogsDays}
+                onChange={(e) => update("cleanupAuditLogsDays", e.target.value)}
+              />
+              <span className="text-sm text-muted-foreground">days</span>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <IconTrash className="size-5" />
+            Bulk Scan Batch Retention
+          </CardTitle>
+          <CardDescription>
+            Old bulk scan batch records are removed after this many days.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label htmlFor="cleanupBulkScansDays">Retention period</Label>
+              <p className="text-xs text-muted-foreground">1 &ndash; 365 days</p>
+            </div>
+            <div className="flex items-center gap-2">
+              <Input
+                id="cleanupBulkScansDays"
+                type="number"
+                min={1}
+                max={365}
+                className="w-24 text-right"
+                value={settings.cleanupBulkScansDays}
+                onChange={(e) => update("cleanupBulkScansDays", e.target.value)}
+              />
+              <span className="text-sm text-muted-foreground">days</span>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <IconCloud className="size-5" />
+            S3 Artifact Cleanup
+          </CardTitle>
+          <CardDescription>
+            When enabled, raw scanner results and SBOMs stored in S3 are deleted alongside
+            their parent scan records during cleanup.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label htmlFor="cleanupS3Artifacts">Delete S3 artifacts on scan cleanup</Label>
+              <p className="text-xs text-muted-foreground">
+                Disable to keep raw results in object storage after scans are purged
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <Switch
+                id="cleanupS3Artifacts"
+                checked={settings.cleanupS3Artifacts === "true"}
+                onCheckedChange={(checked) =>
+                  update("cleanupS3Artifacts", checked ? "true" : "false")
+                }
+              />
+              <Badge variant={settings.cleanupS3Artifacts === "true" ? "default" : "secondary"}>
+                {settings.cleanupS3Artifacts === "true" ? "Enabled" : "Disabled"}
+              </Badge>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <p className="text-xs text-muted-foreground">
+        Cleanup runs automatically 30 seconds after server start and then every 24 hours.
+        Changes take effect on the next cleanup cycle.
+      </p>
+    </div>
+  );
+}

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -51,6 +51,11 @@ const data = {
       url: "/scheduled-scans",
       icon: IconCalendarEvent,
     },
+    {
+      title: "Settings",
+      url: "/settings",
+      icon: IconSettings,
+    },
   ],
 };
 

--- a/src/lib/cleanup.ts
+++ b/src/lib/cleanup.ts
@@ -1,6 +1,8 @@
 /**
  * Database cleanup utilities for Harbor Guard
- * Handles automatic cleanup of old scans based on CLEANUP_OLD_SCANS_DAYS configuration
+ * Handles automatic cleanup of old scans based on configuration.
+ * Settings are read from the app_settings table (UI-configurable),
+ * falling back to CLEANUP_OLD_SCANS_DAYS env var, then default of 30.
  */
 
 import { config } from './config';
@@ -10,6 +12,25 @@ import { DashboardS3Client } from './storage/s3';
 import fs from 'fs/promises';
 import path from 'path';
 
+async function getRetentionSettings() {
+  const defaults = {
+    cleanupOldScansDays: config.cleanupOldScansDays,
+    cleanupAuditLogsDays: config.cleanupOldScansDays,
+    cleanupBulkScansDays: config.cleanupOldScansDays,
+    cleanupS3Artifacts: true,
+  };
+  try {
+    const rows = await prisma.appSetting.findMany();
+    for (const row of rows) {
+      if (row.key === 'cleanupOldScansDays') defaults.cleanupOldScansDays = parseInt(row.value) || defaults.cleanupOldScansDays;
+      if (row.key === 'cleanupAuditLogsDays') defaults.cleanupAuditLogsDays = parseInt(row.value) || defaults.cleanupAuditLogsDays;
+      if (row.key === 'cleanupBulkScansDays') defaults.cleanupBulkScansDays = parseInt(row.value) || defaults.cleanupBulkScansDays;
+      if (row.key === 'cleanupS3Artifacts') defaults.cleanupS3Artifacts = row.value !== 'false';
+    }
+  } catch { /* use defaults if table doesn't exist yet */ }
+  return defaults;
+}
+
 export class DatabaseCleanup {
   private workDir = process.env.SCANNER_WORKDIR || '/workspace';
 
@@ -18,10 +39,12 @@ export class DatabaseCleanup {
    */
   async cleanupOldScans(): Promise<void> {
     try {
-      const cutoffDate = new Date();
-      cutoffDate.setDate(cutoffDate.getDate() - config.cleanupOldScansDays);
+      const retention = await getRetentionSettings();
 
-      logger.info(`Starting cleanup of scans older than ${config.cleanupOldScansDays} days (before ${cutoffDate.toISOString()})`);
+      const cutoffDate = new Date();
+      cutoffDate.setDate(cutoffDate.getDate() - retention.cleanupOldScansDays);
+
+      logger.info(`Starting cleanup of scans older than ${retention.cleanupOldScansDays} days (before ${cutoffDate.toISOString()})`);
 
       let cleanupCount = 0;
       let errorCount = 0;
@@ -66,7 +89,7 @@ export class DatabaseCleanup {
         }
 
         // Clean up S3 artifacts before deleting DB records
-        if (DashboardS3Client.isConfigured()) {
+        if (retention.cleanupS3Artifacts && DashboardS3Client.isConfigured()) {
           try {
             const s3 = DashboardS3Client.getInstance();
             for (const scan of batch) {
@@ -107,11 +130,15 @@ export class DatabaseCleanup {
         logger.warn(`Cleanup reached max iteration limit (${MAX_ITERATIONS}); some old scans may remain`);
       }
 
-      // Clean up orphaned bulk scan items
-      await this.cleanupOrphanedBulkScanItems(cutoffDate);
+      // Clean up orphaned bulk scan items (may have independent retention)
+      const bulkCutoff = new Date();
+      bulkCutoff.setDate(bulkCutoff.getDate() - retention.cleanupBulkScansDays);
+      await this.cleanupOrphanedBulkScanItems(bulkCutoff);
 
-      // Clean up orphaned audit logs
-      await this.cleanupOldAuditLogs(cutoffDate);
+      // Clean up orphaned audit logs (may have independent retention)
+      const auditCutoff = new Date();
+      auditCutoff.setDate(auditCutoff.getDate() - retention.cleanupAuditLogsDays);
+      await this.cleanupOldAuditLogs(auditCutoff);
 
       logger.info(`Cleanup completed: ${cleanupCount} scans cleaned, ${errorCount} errors`);
 


### PR DESCRIPTION
## Summary
- Add `AppSetting` key-value model with migration for persisted runtime configuration
- Add `GET/PUT /api/settings` endpoint with validation (1-365 day ranges, boolean toggle)
- Update cleanup system to read retention settings from DB, falling back to env vars
- Independent retention periods for: scans, audit logs, bulk scan batches
- Toggleable S3 artifact cleanup (can keep raw results after scan records are purged)
- New `/settings` page with card-based UI for each retention category
- Settings link added to sidebar navigation

## Test plan
- [ ] `/settings` page loads with default values (30 days each, S3 cleanup enabled)
- [ ] Changing a value and clicking Save persists to DB and shows success toast
- [ ] Invalid values (0, 400, non-numeric) are rejected with error toast
- [ ] Next cleanup cycle uses the updated retention values
- [ ] S3 toggle set to off skips artifact deletion during cleanup