### PR TITLE
fix: harden API endpoints and fix registryType bug from branch RCA

### DIFF
--- a/src/app/api/images/route.ts
+++ b/src/app/api/images/route.ts
@@ -77,7 +77,8 @@ export async function GET(request: NextRequest) {
         orderBy: { createdAt: 'desc' },
         include: {
           scans: includeScans ? {
-            orderBy: { createdAt: 'desc' }
+            orderBy: { createdAt: 'desc' },
+            take: 10
           } : false
         }
       }),

--- a/src/app/api/patches/history/route.ts
+++ b/src/app/api/patches/history/route.ts
@@ -6,8 +6,8 @@ export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
     const imageId = searchParams.get('imageId');
-    const limit = parseInt(searchParams.get('limit') || '50');
-    const offset = parseInt(searchParams.get('offset') || '0');
+    const limit = Math.max(1, Math.min(parseInt(searchParams.get('limit') || '50') || 50, 100));
+    const offset = Math.max(0, parseInt(searchParams.get('offset') || '0') || 0);
 
     const whereClause = imageId 
       ? {

--- a/src/app/api/scans/[id]/findings/route.ts
+++ b/src/app/api/scans/[id]/findings/route.ts
@@ -14,6 +14,8 @@ export async function GET(
     const search = searchParams.get('search') || '';
     const severity = searchParams.get('severity') || '';
     const source = searchParams.get('source') || '';
+    const limit = Math.max(1, Math.min(parseInt(searchParams.get('limit') || '500') || 500, 2000));
+    const offset = Math.max(0, parseInt(searchParams.get('offset') || '0') || 0);
 
     // Verify scan exists
     const scan = await prisma.scan.findUnique({
@@ -78,14 +80,19 @@ export async function GET(
 
     // Fetch vulnerabilities
     if (type === 'vulnerabilities' || type === 'all') {
-      const vulnerabilities = await prisma.scanVulnerabilityFinding.findMany({
-        where: buildWhereClause('vulnerabilities'),
-        orderBy: [
-          { severity: 'desc' },
-          { cvssScore: 'desc' },
-          { cveId: 'asc' }
-        ]
-      });
+      const [vulnerabilities, vulnTotal] = await Promise.all([
+        prisma.scanVulnerabilityFinding.findMany({
+          where: buildWhereClause('vulnerabilities'),
+          orderBy: [
+            { severity: 'desc' },
+            { cvssScore: 'desc' },
+            { cveId: 'asc' }
+          ],
+          take: limit,
+          skip: offset
+        }),
+        prisma.scanVulnerabilityFinding.count({ where: buildWhereClause('vulnerabilities') })
+      ]);
 
       // Group vulnerabilities by source for summary
       const vulnBySource: Record<string, any> = {};
@@ -111,22 +118,28 @@ export async function GET(
       });
 
       result.vulnerabilities = {
-        total: vulnerabilities.length,
+        total: vulnTotal,
         bySeverity: vulnBySeverity,
         bySource: Object.values(vulnBySource),
-        findings: vulnerabilities
+        findings: vulnerabilities,
+        pagination: { total: vulnTotal, limit, offset, hasMore: offset + limit < vulnTotal }
       };
     }
 
     // Fetch packages
     if (type === 'packages' || type === 'all') {
-      const packages = await prisma.scanPackageFinding.findMany({
-        where: buildWhereClause('packages'),
-        orderBy: [
-          { packageName: 'asc' },
-          { version: 'asc' }
-        ]
-      });
+      const [packages, pkgTotal] = await Promise.all([
+        prisma.scanPackageFinding.findMany({
+          where: buildWhereClause('packages'),
+          orderBy: [
+            { packageName: 'asc' },
+            { version: 'asc' }
+          ],
+          take: limit,
+          skip: offset
+        }),
+        prisma.scanPackageFinding.count({ where: buildWhereClause('packages') })
+      ]);
 
       // Group packages by type and source
       const pkgByType: Record<string, number> = {};
@@ -142,24 +155,30 @@ export async function GET(
       });
 
       result.packages = {
-        total: packages.length,
+        total: pkgTotal,
         byType: pkgByType,
         bySource: pkgBySource,
         byEcosystem: pkgByEcosystem,
-        findings: packages
+        findings: packages,
+        pagination: { total: pkgTotal, limit, offset, hasMore: offset + limit < pkgTotal }
       };
     }
 
     // Fetch compliance findings
     if (type === 'compliance' || type === 'all') {
-      const compliance = await prisma.scanComplianceFinding.findMany({
-        where: buildWhereClause('compliance'),
-        orderBy: [
-          { severity: 'desc' },
-          { category: 'asc' },
-          { ruleName: 'asc' }
-        ]
-      });
+      const [compliance, compTotal] = await Promise.all([
+        prisma.scanComplianceFinding.findMany({
+          where: buildWhereClause('compliance'),
+          orderBy: [
+            { severity: 'desc' },
+            { category: 'asc' },
+            { ruleName: 'asc' }
+          ],
+          take: limit,
+          skip: offset
+        }),
+        prisma.scanComplianceFinding.count({ where: buildWhereClause('compliance') })
+      ]);
 
       // Group compliance by category and severity
       const compByCategory: Record<string, number> = {};
@@ -177,22 +196,28 @@ export async function GET(
       });
 
       result.compliance = {
-        total: compliance.length,
+        total: compTotal,
         bySeverity: compBySeverity,
         byCategory: compByCategory,
-        findings: compliance
+        findings: compliance,
+        pagination: { total: compTotal, limit, offset, hasMore: offset + limit < compTotal }
       };
     }
 
     // Fetch efficiency findings
     if (type === 'efficiency' || type === 'all') {
-      const efficiency = await prisma.scanEfficiencyFinding.findMany({
-        where: { scanId },
-        orderBy: [
-          { wastedBytes: 'desc' },
-          { sizeBytes: 'desc' }
-        ]
-      });
+      const [efficiency, effTotal] = await Promise.all([
+        prisma.scanEfficiencyFinding.findMany({
+          where: { scanId },
+          orderBy: [
+            { wastedBytes: 'desc' },
+            { sizeBytes: 'desc' }
+          ],
+          take: limit,
+          skip: offset
+        }),
+        prisma.scanEfficiencyFinding.count({ where: { scanId } })
+      ]);
 
       // Group efficiency by type
       const effByType: Record<string, number> = {};
@@ -206,7 +231,7 @@ export async function GET(
       });
 
       result.efficiency = {
-        total: efficiency.length,
+        total: effTotal,
         byType: effByType,
         totalWastedBytes: totalWastedBytes.toString(),
         totalSizeBytes: totalSizeBytes.toString(),
@@ -214,7 +239,8 @@ export async function GET(
           ...eff,
           wastedBytes: eff.wastedBytes?.toString(),
           sizeBytes: eff.sizeBytes?.toString()
-        }))
+        })),
+        pagination: { total: effTotal, limit, offset, hasMore: offset + limit < effTotal }
       };
     }
 

--- a/src/app/api/scans/[id]/route.ts
+++ b/src/app/api/scans/[id]/route.ts
@@ -266,8 +266,8 @@ export async function GET(
     const { id } = await params
     const { searchParams } = new URL(request.url)
     const includeJsonb = searchParams.get('includeJsonb') === 'true'
-    const packageLimit = parseInt(searchParams.get('packageLimit') || '100')
-    const packagePage = parseInt(searchParams.get('packagePage') || '0')
+    const packageLimit = Math.max(1, Math.min(parseInt(searchParams.get('packageLimit') || '100') || 100, 500))
+    const packagePage = Math.max(0, parseInt(searchParams.get('packagePage') || '0') || 0)
 
     // Build metadata select/include based on query params
     const metadataQuery = includeJsonb ? {

--- a/src/app/api/scans/aggregated/route.ts
+++ b/src/app/api/scans/aggregated/route.ts
@@ -57,13 +57,14 @@ export async function GET(request: NextRequest) {
               registryType: true
             }
           },
-          // Include vulnerability findings for accurate counting
+          // Include vulnerability findings only as fallback for scans without metadata
           vulnerabilityFindings: {
             select: {
               cveId: true,
               severity: true,
               source: true
-            }
+            },
+            take: 2000
           }
         },
         orderBy: { startedAt: 'desc' },

--- a/src/lib/scanner/DatabaseAdapter.ts
+++ b/src/lib/scanner/DatabaseAdapter.ts
@@ -68,7 +68,7 @@ export class DatabaseAdapter implements IDatabaseAdapter {
             name: request.image, tag: request.tag, source: 'LOCAL_DOCKER', digest,
             platform: `${imageData.Os}/${imageData.Architecture}`,
             sizeBytes: imageData.Size ? BigInt(imageData.Size) : null,
-            dockerImageId: request.dockerImageId,
+            registryType: 'LOCAL', dockerImageId: request.dockerImageId,
           }
         });
 


### PR DESCRIPTION
## Summary
Fixes identified by root cause analysis of the `fix/api-data-flow` and `origin/refactor/architecture-cleanup` branches. These are the residual issues that were never merged to main.

- **Bug fix**: Add missing `registryType: 'LOCAL'` to local Docker scan init — all locally-scanned images had null `registryType`
- **Pagination hardening**: Cap `patches/history` limit (was uncapped, no NaN guard) and `scans/[id]` `packageLimit` (was uncapped)
- **Unbounded query fix**: Add pagination to `/api/scans/[id]/findings` — previously returned ALL findings with zero limits across 4 finding types
- **Memory guard**: Cap `includeScans` in `/api/images` to 10 most recent; cap vulnerability findings fallback in `/api/scans/aggregated` to 2000

## Test plan
- [ ] Scan a local Docker image and verify `registryType` is `LOCAL` (not null) in the DB
- [ ] Call `GET /api/patches/history?limit=abc` and verify it falls back to 50, not NaN
- [ ] Call `GET /api/scans/{id}/findings` and verify response includes `pagination` objects
- [ ] Call `GET /api/images?includeScans=true` and verify max 10 scans per image