### PR TITLE
fix: handle sensor CLI non-zero exit code with valid stdout

### DIFF
--- a/src/lib/scanner/SensorBridge.ts
+++ b/src/lib/scanner/SensorBridge.ts
@@ -119,7 +119,23 @@ export async function executeScanViaSensor(
 
     const envelope: ScanEnvelope = JSON.parse(stdout);
     return envelope;
-  } catch (error) {
+  } catch (error: any) {
+    // The sensor CLI may exit non-zero but still produce valid JSON on stdout
+    // (e.g. status logs written to stderr cause a non-zero exit code).
+    if (error?.stdout) {
+      try {
+        const envelope: ScanEnvelope = JSON.parse(error.stdout);
+        if (envelope?.scan && envelope?.findings) {
+          if (error.stderr) {
+            logger.debug(`[SensorBridge] stderr (non-fatal): ${String(error.stderr).slice(0, 500)}`);
+          }
+          onProgress?.(85, 'Processing scan results');
+          return envelope;
+        }
+      } catch {
+        // stdout wasn't valid JSON — fall through to the original error
+      }
+    }
     const msg = error instanceof Error ? error.message : String(error);
     logger.error(`[SensorBridge] Sensor scan failed: ${msg}`);
     throw new Error(`Sensor scan failed: ${msg}`);


### PR DESCRIPTION
## Summary
The `harborguard-sensor` CLI writes progress logs to stderr and exits with code 1 even on successful scans. Node's `execFileAsync` throws for any non-zero exit code, causing **all local-sensor scans to fail** with `"Sensor scan failed: Command failed..."`.

Added fallback in the catch handler to parse `error.stdout` for a valid `ScanEnvelope`. If stdout contains valid scan results (with `scan` and `findings` fields), the results are used instead of propagating the error.

Found during end-to-end testing of the scan workflow.

## Test plan
- [x] Start a scan of `alpine:latest` via local sensor — completes successfully
- [x] Scan results include all 6 scanners' findings
- [x] Invalid sensor output still throws properly