### PR TITLE
fix: show 'No Sensor Detected' toast instead of failed scan row

### DIFF
--- a/src/app/api/scans/local-bulk/route.ts
+++ b/src/app/api/scans/local-bulk/route.ts
@@ -3,12 +3,20 @@ import { listDockerImages } from '@/lib/docker';
 import { BulkScanService } from '@/lib/bulk/BulkScanService';
 import { logger } from '@/lib/logger';
 import { prisma } from '@/lib/prisma';
-import { scannerService } from '@/lib/scanner';
+import { scannerService, detectScanMode } from '@/lib/scanner';
 import type { ScanRequest } from '@/types';
 import { apiError } from '@/lib/api/api-utils';
 
 export async function POST(request: NextRequest) {
   try {
+    const scanMode = await detectScanMode();
+    if (scanMode === 'unavailable') {
+      return NextResponse.json(
+        { error: 'No scanner available. Register a sensor agent or deploy the monolith image with the sensor module.' },
+        { status: 503 }
+      );
+    }
+
     logger.info('Starting bulk scan of all local Docker images');
     
     // Get all local Docker images

--- a/src/app/api/scans/start/route.ts
+++ b/src/app/api/scans/start/route.ts
@@ -67,7 +67,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server'
-import { scannerService } from '@/lib/scanner'
+import { scannerService, detectScanMode } from '@/lib/scanner'
 import { z } from 'zod'
 import type { ScanRequest } from '@/types'
 import { auditLogger } from '@/lib/audit-logger'
@@ -246,10 +246,19 @@ async function processBatchScans(scans: any[], priority: number, request: NextRe
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
-    
+
     // Validate request data
     const validatedData = ScanStartSchema.parse(body)
-    
+
+    // Pre-flight check: ensure a scan execution path exists
+    const scanMode = await detectScanMode();
+    if (scanMode === 'unavailable') {
+      return NextResponse.json(
+        { error: 'No scanner available. Register a sensor agent or deploy the monolith image with the sensor module.' },
+        { status: 503 }
+      );
+    }
+
     // Check if this is a batch request
     if ('scans' in validatedData) {
       // Handle batch scan request

--- a/src/hooks/useScanExecution.ts
+++ b/src/hooks/useScanExecution.ts
@@ -156,6 +156,14 @@ export function useScanExecution(
         const data = await response.json()
 
         if (!response.ok) {
+          if (response.status === 503) {
+            toast.error("No Sensor Detected", {
+              description: "Register a sensor agent to enable scanning.",
+            })
+            resetProgress()
+            setIsLoading(false)
+            return
+          }
           throw new Error(data.error || 'Failed to start bulk scan')
         }
 
@@ -276,8 +284,17 @@ export function useScanExecution(
       })
 
       if (!response.ok) {
-        const error = await response.text()
-        throw new Error(error || 'Failed to start scan')
+        const errorData = await response.json().catch(() => null)
+        const errorMsg = errorData?.error || 'Failed to start scan'
+        if (response.status === 503) {
+          toast.error("No Sensor Detected", {
+            description: "Register a sensor agent to enable scanning.",
+          })
+          resetProgress()
+          setIsLoading(false)
+          return
+        }
+        throw new Error(errorMsg)
       }
 
       const result = await response.json()


### PR DESCRIPTION
## Summary
When no sensor agent is registered and a user tries to scan, the scan was accepted (200), created in the database, then immediately failed in the background. The user saw a success toast followed by a FAILED row in the scans table.

Now the API returns 503 upfront if no scan execution path is available, and the frontend catches this to show a clear **"No Sensor Detected"** toast with the message "Register a sensor agent to enable scanning."

**Changes:**
- `POST /api/scans/start`: Pre-flight `detectScanMode()` check, returns 503 if unavailable
- `POST /api/scans/local-bulk`: Same pre-flight check
- `useScanExecution.ts`: Catches 503 responses and shows specific toast for both single and bulk scan paths

## Test plan
- [ ] With no sensor registered, attempt a scan — should see "No Sensor Detected" toast, no scan row created
- [ ] With sensor registered, attempt a scan — should work normally
- [ ] Bulk scan with no sensor — should see same toast