### PR TITLE
feat: auto-bootstrap sensor agent from shared HG_API_KEY

### DIFF
--- a/docker-compose.distributed.yml
+++ b/docker-compose.distributed.yml
@@ -16,6 +16,7 @@ services:
       - S3_SECRET_KEY=minioadmin
       - LOG_LEVEL=info
       - HEALTH_CHECK_ENABLED=true
+      - HG_API_KEY=${HG_API_KEY:-hg_ak_default_distributed_key_change_me}
     depends_on:
       db:
         condition: service_healthy
@@ -32,7 +33,7 @@ services:
       - sensor-cache:/workspace/cache
     environment:
       - HG_DASHBOARD_URL=http://dashboard:3000
-      - HG_API_KEY=${HG_API_KEY:-}
+      - HG_API_KEY=${HG_API_KEY:-hg_ak_default_distributed_key_change_me}
       - HG_AGENT_NAME=local-sensor
       - HG_S3_ENDPOINT=http://minio:9000
       - HG_S3_BUCKET=harborguard

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -2,7 +2,36 @@ export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
     const { scheduleAutoCleanup } = await import('./lib/cleanup');
     scheduleAutoCleanup();
+    await bootstrapAgentKey();
     await initializeDemoMode();
+  }
+}
+
+async function bootstrapAgentKey() {
+  const bootstrapKey = process.env.HG_API_KEY;
+  if (!bootstrapKey || !bootstrapKey.startsWith('hg_ak_')) return;
+
+  try {
+    const crypto = await import('crypto');
+    const { prisma } = await import('./lib/prisma');
+
+    const hash = crypto.createHash('sha256').update(bootstrapKey).digest('hex');
+
+    // Skip if an agent with this key already exists
+    const existing = await prisma.agent.findFirst({ where: { apiKeyHash: hash } });
+    if (existing) return;
+
+    await prisma.agent.create({
+      data: {
+        name: 'bootstrap-sensor',
+        apiKeyHash: hash,
+        status: 'DISCONNECTED',
+        capabilities: ['scan'],
+      },
+    });
+    console.log('[bootstrap] Auto-registered agent from HG_API_KEY');
+  } catch (error) {
+    console.warn('[bootstrap] Failed to seed agent key:', error);
   }
 }
 


### PR DESCRIPTION
## Summary
Eliminates the manual agent registration step for distributed deployments.

On startup, if `HG_API_KEY` is set on the dashboard, it auto-creates a bootstrap agent seeded with that key's hash. The same default key is now set on both the dashboard and sensor in `docker-compose.distributed.yml`, so `docker compose up` works out of the box.

**Changes:**
- `src/instrumentation.ts`: Add `bootstrapAgentKey()` that seeds an agent from `HG_API_KEY` on first boot (idempotent)
- `docker-compose.distributed.yml`: Set matching default `HG_API_KEY` on both dashboard and sensor services

Users can override with `HG_API_KEY=<custom> docker compose up`.

## Test plan
- [ ] `docker compose -f docker-compose.distributed.yml up` with no env vars — sensor registers automatically
- [ ] Repeat — agent not duplicated (idempotent)
- [ ] Override `HG_API_KEY=hg_ak_custom...` — uses custom key instead