### PR TITLE
fix: replace broken downloads badge with GHCR package link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 </p>
 
 [![Stars](https://img.shields.io/github/stars/HarborGuard/HarborGuard?color=5B5BD6&style=flat-square)](https://github.com/HarborGuard/HarborGuard)
-[![Downloads](https://img.shields.io/github/downloads/HarborGuard/HarborGuard/total?style=flat-square&label=downloads&color=2496ED&logo=github)](https://github.com/HarborGuard/HarborGuard/releases)
+[![GHCR](https://img.shields.io/badge/GHCR-harborguard-2496ED?style=flat-square&logo=docker)](https://github.com/HarborGuard/HarborGuard/pkgs/container/harborguard)
 [![Next.js](https://img.shields.io/badge/Next.js-15.4.6-black?style=flat-square&logo=next.js)](https://nextjs.org/)
 [![React](https://img.shields.io/badge/React-19.1.0-blue?style=flat-square&logo=react)](https://reactjs.org/)
 [![Docker](https://img.shields.io/badge/Docker-enabled-2496ED?style=flat-square&logo=docker)](https://www.docker.com/)


### PR DESCRIPTION
## Summary
- GitHub releases have no binary assets, so `github/downloads` always shows 0
- GHCR doesn't expose public pull counts via any shields.io-compatible API
- Replaced with a static "GHCR: harborguard" badge linking to the package page

## Test plan
- [x] Verified badge renders correctly via direct fetch