### PR TITLE
fix: use backage API for GHCR download count badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 </p>
 
 [![Stars](https://img.shields.io/github/stars/HarborGuard/HarborGuard?color=5B5BD6&style=flat-square)](https://github.com/HarborGuard/HarborGuard)
-[![GHCR](https://img.shields.io/badge/GHCR-harborguard-2496ED?style=flat-square&logo=docker)](https://github.com/HarborGuard/HarborGuard/pkgs/container/harborguard)
+[![Downloads](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fipitio.github.io%2Fbackage%2FHarborGuard%2FHarborGuard%2Fharborguard.json&query=%24.downloads&label=downloads&color=2496ED&style=flat-square&logo=docker)](https://github.com/HarborGuard/HarborGuard/pkgs/container/harborguard)
 [![Next.js](https://img.shields.io/badge/Next.js-15.4.6-black?style=flat-square&logo=next.js)](https://nextjs.org/)
 [![React](https://img.shields.io/badge/React-19.1.0-blue?style=flat-square&logo=react)](https://reactjs.org/)
 [![Docker](https://img.shields.io/badge/Docker-enabled-2496ED?style=flat-square&logo=docker)](https://www.docker.com/)


### PR DESCRIPTION
## Summary
- GHCR doesn't expose download counts via shields.io or public API
- [backage](https://github.com/ipitio/backage) is the standard solution — indexes GHCR stats and serves JSON for shields.io dynamic badges
- Starred the backage repo to trigger indexing of HarborGuard (takes a few hours)
- Badge will show actual download count (403K+ per the GHCR page) once indexed

## Test plan
- [ ] Verify badge populates after backage indexes HarborGuard