### PR TITLE
fix: cosign signing with correct manifest digest

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -140,7 +140,7 @@ jobs:
       - name: Sign the published Docker image
         env:
           TAGS: ${{ steps.meta.outputs.tags }}
-          DIGEST: ${{ steps.meta.outputs.tags && '' }}
         run: |
-          MANIFEST_DIGEST=$(docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ steps.meta.outputs.version }} --format '{{.Manifest.Digest}}')
-          echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${MANIFEST_DIGEST}
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ steps.meta.outputs.version }}"
+          DIGEST=$(docker buildx imagetools inspect "$IMAGE" | grep -m1 'Digest:' | awk '{print $2}')
+          echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}


### PR DESCRIPTION
## Summary
- Fix cosign signing step that failed in #181 merge job
- `--format '{{.Manifest.Digest}}'` returns the full Go struct, not the digest string
- Parse the digest from plain `docker buildx imagetools inspect` output instead

## Context
Follow-up to PR #181. The build and manifest merge succeeded but signing failed with `could not parse reference` because the digest variable contained the full manifest struct.