### PR TITLE
feat(classifications): ignore vulnerabilities (#154)

### DIFF
--- a/prisma/migrations/20260504130000_add_cve_classification_ignore_fields/migration.sql
+++ b/prisma/migrations/20260504130000_add_cve_classification_ignore_fields/migration.sql
@@ -1,0 +1,10 @@
+-- Add isIgnored and ignoreReason to cve_classifications so the user can mark
+-- a vulnerability as accepted-risk (distinct from "false positive" / scanner
+-- error). The default vulnerability list filters these out client-side. See
+-- HarborGuard issue #154.
+
+ALTER TABLE "cve_classifications"
+  ADD COLUMN "isIgnored"    BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN "ignoreReason" TEXT;
+
+CREATE INDEX "cve_classifications_isIgnored_idx" ON "cve_classifications"("isIgnored");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -544,6 +544,13 @@ model CveClassification {
   id                   String             @id @default(cuid())
   imageVulnerabilityId String
   isFalsePositive      Boolean            @default(false)
+  // isIgnored marks a vulnerability as known/accepted-risk so it stops appearing
+  // in the default vulnerability lists. Distinct from isFalsePositive (where the
+  // scanner is wrong); ignored means the scanner is right but the user has
+  // chosen to accept the risk (e.g. low-severity CVE on an internal-only image,
+  // CVE awaiting upstream package patch). See issue #154.
+  isIgnored            Boolean            @default(false)
+  ignoreReason         String?
   comment              String?
   createdAt            DateTime           @default(now())
   updatedAt            DateTime           @updatedAt
@@ -555,6 +562,7 @@ model CveClassification {
   @@index([imageVulnerabilityId])
   @@index([imageId])
   @@index([isFalsePositive])
+  @@index([isIgnored])
   @@map("cve_classifications")
 }
 

--- a/src/app/api/images/[id]/cve-classifications/[cveId]/route.ts
+++ b/src/app/api/images/[id]/cve-classifications/[cveId]/route.ts
@@ -6,6 +6,8 @@ import { apiError } from '@/lib/api/api-utils';
 
 const UpdateCveClassificationSchema = z.object({
   isFalsePositive: z.boolean().optional(),
+  isIgnored: z.boolean().optional(),
+  ignoreReason: z.string().nullable().optional(),
   comment: z.string().nullable().optional(),
   createdBy: z.string().nullable().optional(),
 });

--- a/src/app/api/images/[id]/cve-classifications/route.ts
+++ b/src/app/api/images/[id]/cve-classifications/route.ts
@@ -9,6 +9,8 @@ const CveClassificationSchema = z.object({
   cveId: z.string().min(1, 'CVE ID is required'),
   packageName: z.string().min(1, 'Package name is required'),
   isFalsePositive: z.boolean().optional().default(false),
+  isIgnored: z.boolean().optional().default(false),
+  ignoreReason: z.string().nullable().optional(),
   comment: z.string().nullable().optional(),
   createdBy: z.string().nullable().optional(),
 });
@@ -111,6 +113,8 @@ export async function POST(
         where: { id: existingClassification.id },
         data: {
           isFalsePositive: validatedData.isFalsePositive,
+          isIgnored: validatedData.isIgnored,
+          ignoreReason: validatedData.ignoreReason,
           comment: validatedData.comment,
           createdBy: validatedData.createdBy,
           updatedAt: new Date(),
@@ -123,6 +127,8 @@ export async function POST(
           imageVulnerabilityId: imageVulnerability.id,
           imageId,
           isFalsePositive: validatedData.isFalsePositive,
+          isIgnored: validatedData.isIgnored,
+          ignoreReason: validatedData.ignoreReason,
           comment: validatedData.comment,
           createdBy: validatedData.createdBy,
         },
@@ -135,7 +141,11 @@ export async function POST(
       validatedData.cveId,
       image.name,
       validatedData.isFalsePositive,
-      validatedData.comment ?? undefined
+      validatedData.comment ?? undefined,
+      {
+        isIgnored: validatedData.isIgnored,
+        ignoreReason: validatedData.ignoreReason ?? undefined,
+      }
     );
 
     // Recalculate risk scores for all scans of this image

--- a/src/app/api/images/name/[name]/cve-classifications/route.ts
+++ b/src/app/api/images/name/[name]/cve-classifications/route.ts
@@ -8,6 +8,8 @@ import { apiError } from '@/lib/api/api-utils';
 const CveClassificationSchema = z.object({
   cveId: z.string().min(1, 'CVE ID is required'),
   isFalsePositive: z.boolean().optional().default(false),
+  isIgnored: z.boolean().optional().default(false),
+  ignoreReason: z.string().nullable().optional(),
   comment: z.string().nullable().optional(),
   createdBy: z.string().nullable().optional(),
 });
@@ -152,6 +154,8 @@ export async function POST(
           where: { id: existingClassification.id },
           data: {
             isFalsePositive: validatedData.isFalsePositive,
+            isIgnored: validatedData.isIgnored,
+            ignoreReason: validatedData.ignoreReason,
             comment: validatedData.comment,
             createdBy: validatedData.createdBy,
             updatedAt: new Date()
@@ -163,6 +167,8 @@ export async function POST(
             imageVulnerabilityId: imageVulnerability.id,
             imageId: image.id,
             isFalsePositive: validatedData.isFalsePositive,
+            isIgnored: validatedData.isIgnored,
+            ignoreReason: validatedData.ignoreReason,
             comment: validatedData.comment,
             createdBy: validatedData.createdBy,
           }
@@ -178,7 +184,11 @@ export async function POST(
       validatedData.cveId,
       imageName,
       validatedData.isFalsePositive,
-      validatedData.comment ?? undefined
+      validatedData.comment ?? undefined,
+      {
+        isIgnored: validatedData.isIgnored,
+        ignoreReason: validatedData.ignoreReason ?? undefined,
+      }
     );
 
     // Recalculate risk scores for affected images

--- a/src/app/api/scans/[id]/cve-classifications/route.ts
+++ b/src/app/api/scans/[id]/cve-classifications/route.ts
@@ -7,6 +7,8 @@ const CveClassificationSchema = z.object({
   cveId: z.string().min(1, 'CVE ID is required'),
   packageName: z.string().min(1, 'Package name is required'),
   isFalsePositive: z.boolean().optional().default(false),
+  isIgnored: z.boolean().optional().default(false),
+  ignoreReason: z.string().nullable().optional(),
   comment: z.string().nullable().optional(),
   createdBy: z.string().nullable().optional(),
 });
@@ -156,6 +158,8 @@ export async function POST(
         where: { id: existingClassification.id },
         data: {
           isFalsePositive: validatedData.isFalsePositive,
+          isIgnored: validatedData.isIgnored,
+          ignoreReason: validatedData.ignoreReason,
           comment: validatedData.comment,
           updatedAt: new Date(),
         }
@@ -167,6 +171,8 @@ export async function POST(
           imageId: scan.imageId,
           imageVulnerabilityId: imageVulnerability.id,
           isFalsePositive: validatedData.isFalsePositive ?? false,
+          isIgnored: validatedData.isIgnored ?? false,
+          ignoreReason: validatedData.ignoreReason,
           comment: validatedData.comment,
           createdBy: validatedData.createdBy || 'system',
         }

--- a/src/app/images/[name]/[scanId]/page.tsx
+++ b/src/app/images/[name]/[scanId]/page.tsx
@@ -63,6 +63,10 @@ export default function ScanResultsPage() {
     React.useState(false);
   const [selectedCveId, setSelectedCveId] = React.useState<string>("");
   const [showFalsePositives, setShowFalsePositives] = React.useState(true);
+  // Default-hide ignored vulnerabilities so the user's risk-accepted findings
+  // don't pollute the main list. Toggle exposed via the same control surface
+  // as showFalsePositives. Tracks issue #154.
+  const [showIgnored, setShowIgnored] = React.useState(false);
 
   // Vulnerability details modal state
   const [selectedVulnerability, setSelectedVulnerability] =
@@ -300,6 +304,7 @@ export default function ScanResultsPage() {
             scanId={scanId}
             scanData={scanData}
             showFalsePositives={showFalsePositives}
+            showIgnored={showIgnored}
             consolidatedClassifications={consolidatedClassifications}
             onClassificationChange={fetchConsolidatedClassifications}
           />

--- a/src/components/dialogs/cve-classification-dialog.tsx
+++ b/src/components/dialogs/cve-classification-dialog.tsx
@@ -22,9 +22,11 @@ interface CveClassificationDialogProps {
   cveId: string
   imageId: string
   currentClassification?: CveClassification | null
-  onSave: (data: { 
+  onSave: (data: {
     cveId: string;
     isFalsePositive: boolean;
+    isIgnored: boolean;
+    ignoreReason?: string | null;
     comment?: string | null;
     createdBy?: string | null;
   }) => Promise<void>
@@ -41,6 +43,12 @@ export function CveClassificationDialog({
   const [isFalsePositive, setIsFalsePositive] = useState(
     currentClassification?.isFalsePositive ?? false
   )
+  const [isIgnored, setIsIgnored] = useState(
+    currentClassification?.isIgnored ?? false
+  )
+  const [ignoreReason, setIgnoreReason] = useState(
+    currentClassification?.ignoreReason || ""
+  )
   const [comment, setComment] = useState(currentClassification?.comment || "")
   const [createdBy, setCreatedBy] = useState(currentClassification?.createdBy || "")
   const [isSaving, setIsSaving] = useState(false)
@@ -51,6 +59,8 @@ export function CveClassificationDialog({
       await onSave({
         cveId,
         isFalsePositive,
+        isIgnored,
+        ignoreReason: isIgnored ? (ignoreReason.trim() || null) : null,
         comment: comment.trim() || null,
         createdBy: createdBy.trim() || null,
       })
@@ -85,6 +95,32 @@ export function CveClassificationDialog({
               Mark as false positive
             </Label>
           </div>
+          <div className="flex items-center space-x-2">
+            <Checkbox
+              id="ignored"
+              checked={isIgnored}
+              onCheckedChange={(checked) => setIsIgnored(checked as boolean)}
+            />
+            <Label
+              htmlFor="ignored"
+              className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+            >
+              Ignore (accepted risk — hide from default list)
+            </Label>
+          </div>
+          {isIgnored && (
+            <div className="grid gap-2 pl-6">
+              <Label htmlFor="ignoreReason" className="text-xs text-muted-foreground">
+                Reason (optional, e.g. "internal-only image", "awaiting upstream patch")
+              </Label>
+              <Input
+                id="ignoreReason"
+                placeholder="Why is this risk accepted?"
+                value={ignoreReason}
+                onChange={(e) => setIgnoreReason(e.target.value)}
+              />
+            </div>
+          )}
           <div className="grid gap-2">
             <Label htmlFor="comment">Comment</Label>
             <Textarea

--- a/src/components/scan/ScanDetailsNormalized.tsx
+++ b/src/components/scan/ScanDetailsNormalized.tsx
@@ -34,6 +34,10 @@ interface ScanDetailsNormalizedProps {
   scanId: string;
   scanData: any;
   showFalsePositives: boolean;
+  // Defaults to false (i.e. ignored vulns are hidden from the default
+  // vulnerability list) per #154. The parent page controls the toggle so the
+  // setting can persist across tabs.
+  showIgnored?: boolean;
   consolidatedClassifications: any[];
   onClassificationChange: () => void;
 }
@@ -42,6 +46,7 @@ export function ScanDetailsNormalized({
   scanId,
   scanData,
   showFalsePositives,
+  showIgnored = false,
   consolidatedClassifications,
   onClassificationChange
 }: ScanDetailsNormalizedProps) {
@@ -102,6 +107,11 @@ export function ScanDetailsNormalized({
     return classification?.isFalsePositive ?? false;
   };
 
+  const isIgnored = (cveId: string) => {
+    const classification = getClassification(cveId);
+    return classification?.isIgnored ?? false;
+  };
+
   const getComment = (cveId: string) => {
     const classification = getClassification(cveId);
     return classification?.comment || undefined;
@@ -131,11 +141,21 @@ export function ScanDetailsNormalized({
     return <div className="p-4">No findings available</div>;
   }
 
-  // Filter out false positives if needed
-  const filterFalsePositives = (items: any[]) => {
-    if (showFalsePositives) return items;
-    return items.filter(item => !isFalsePositive(item.cveId || item.id));
+  // Filter out false positives and/or ignored vulnerabilities depending on
+  // the parent's toggles. Defaults: hide both. See issue #154.
+  const filterClassified = (items: any[]) => {
+    return items.filter((item) => {
+      const cveId = item.cveId || item.id;
+      if (!showFalsePositives && isFalsePositive(cveId)) return false;
+      if (!showIgnored && isIgnored(cveId)) return false;
+      return true;
+    });
   };
+
+  // Kept as an alias for callers that previously imported the FP-only filter,
+  // so this PR can land without re-typing every callsite. Behavior matches
+  // the new combined filter.
+  const filterFalsePositives = filterClassified;
 
   return (
     <div className="space-y-6">
@@ -251,7 +271,7 @@ export function ScanDetailsNormalized({
         {/* Vulnerabilities Tab */}
         <TabsContent value="vulnerabilities">
           <VulnerabilitiesTab
-            vulnerabilities={filterFalsePositives(findings.vulnerabilities?.findings || [])}
+            vulnerabilities={filterClassified(findings.vulnerabilities?.findings || [])}
             vulnerabilitySearch={vulnerabilitySearch}
             onVulnerabilitySearchChange={setVulnerabilitySearch}
             sortField={sortField}
@@ -259,6 +279,7 @@ export function ScanDetailsNormalized({
             onSortFieldChange={setSortField}
             onSortOrderToggle={() => setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc')}
             isFalsePositive={isFalsePositive}
+            isIgnored={isIgnored}
             getComment={getComment}
             getSourceBadge={getSourceBadge}
             onVulnerabilityClick={(vuln) => {
@@ -346,6 +367,8 @@ export function ScanDetailsNormalized({
                   cveId: classification.cveId,
                   packageName: selectedPackageName,
                   isFalsePositive: classification.isFalsePositive,
+                  isIgnored: classification.isIgnored,
+                  ignoreReason: classification.ignoreReason,
                   comment: classification.comment,
                   createdBy: classification.createdBy
                 })

--- a/src/components/scan/findings/VulnerabilitiesTab.tsx
+++ b/src/components/scan/findings/VulnerabilitiesTab.tsx
@@ -38,6 +38,9 @@ interface VulnerabilitiesTabProps {
   onSortFieldChange: (field: string) => void;
   onSortOrderToggle: () => void;
   isFalsePositive: (cveId: string) => boolean;
+  // Returns true if the vuln has been marked as accepted-risk / ignored.
+  // Optional so older callers that haven't been migrated still compile.
+  isIgnored?: (cveId: string) => boolean;
   getComment: (cveId: string) => string | undefined;
   getSourceBadge: (source: string) => React.ReactNode;
   onVulnerabilityClick: (vuln: any) => void;
@@ -103,11 +106,13 @@ export function VulnerabilitiesTab({
   onSortFieldChange,
   onSortOrderToggle,
   isFalsePositive,
+  isIgnored,
   getComment,
   getSourceBadge,
   onVulnerabilityClick,
   onClassifyClick,
 }: VulnerabilitiesTabProps) {
+  const isIgnoredFn = isIgnored ?? (() => false);
   const handleSort = (field: string) => {
     if (sortField === field) {
       onSortOrderToggle();
@@ -177,18 +182,23 @@ export function VulnerabilitiesTab({
           <TableBody>
             {sortFindings(filterVulnerabilities(vulnerabilities, vulnerabilitySearch), sortField, sortOrder).map((vuln: any) => {
               const comment = getComment(vuln.cveId);
+              const ignored = isIgnoredFn(vuln.cveId);
+              const fp = isFalsePositive(vuln.cveId);
               return (
                 <TableRow
                   key={`${vuln.id}-${vuln.source}`}
-                  className={`${isFalsePositive(vuln.cveId) ? 'opacity-50' : ''} cursor-pointer hover:bg-muted/50`}
+                  className={`${(fp || ignored) ? 'opacity-50' : ''} cursor-pointer hover:bg-muted/50`}
                   onClick={() => onVulnerabilityClick(vuln)}
                 >
                   <TableCell>
                     <div className="space-y-1">
                       <div className="flex items-center gap-2">
                         <span className="font-mono text-sm">{vuln.cveId}</span>
-                        {isFalsePositive(vuln.cveId) && (
+                        {fp && (
                           <Badge variant="outline" className="text-xs">FP</Badge>
+                        )}
+                        {ignored && (
+                          <Badge variant="outline" className="text-xs">Ignored</Badge>
                         )}
                       </div>
                       {comment && (

--- a/src/lib/audit-logger.ts
+++ b/src/lib/audit-logger.ts
@@ -239,26 +239,40 @@ export const auditLogger = {
 
   /**
    * Log CVE classification
+   *
+   * `extra.isIgnored` distinguishes "user accepts this risk and wants it
+   * out of default lists" from "scanner is wrong" (`isFalsePositive`).
+   * See issue #154.
    */
   cveClassification: async (
-    request: NextRequest, 
-    cveId: string, 
-    imageName: string, 
+    request: NextRequest,
+    cveId: string,
+    imageName: string,
     isFalsePositive: boolean,
-    comment?: string
+    comment?: string,
+    extra?: { isIgnored?: boolean; ignoreReason?: string }
   ) => {
-    const action = isFalsePositive 
-      ? `Marked ${cveId} as false positive for ${imageName}${comment ? ` with comment "${comment}"` : ''}`
-      : `Updated classification for ${cveId} on ${imageName}`;
-      
+    const isIgnored = extra?.isIgnored === true;
+    const ignoreReason = extra?.ignoreReason;
+
+    let action: string;
+    if (isIgnored) {
+      const reasonSuffix = ignoreReason ? ` (reason: "${ignoreReason}")` : '';
+      action = `Ignored ${cveId} on ${imageName}${reasonSuffix}`;
+    } else if (isFalsePositive) {
+      action = `Marked ${cveId} as false positive for ${imageName}${comment ? ` with comment "${comment}"` : ''}`;
+    } else {
+      action = `Updated classification for ${cveId} on ${imageName}`;
+    }
+
     await logAuditEventFromRequest(
       request,
       'cve_classification',
       'action',
       action,
-      { 
+      {
         resource: `${imageName}:${cveId}`,
-        details: { cveId, imageName, isFalsePositive, comment }
+        details: { cveId, imageName, isFalsePositive, isIgnored, ignoreReason, comment }
       }
     );
   },


### PR DESCRIPTION
Closes #154.

The reporter wanted to be able to mark vulnerabilities as known/accepted-risk so they stop crowding out the actually-concerning ones in the list. Existing `isFalsePositive` is close but doesn't quite mean the same thing — "scanner is wrong" vs "scanner is right but I'm not acting on this." So this adds a parallel `isIgnored` field rather than overloading FP.

## Schema

New migration `20260504130000_add_cve_classification_ignore_fields` adds:

- `isIgnored: BOOLEAN NOT NULL DEFAULT false` on `cve_classifications`
- `ignoreReason: TEXT NULL`
- Index on `isIgnored` so the future global vuln-list filter stays cheap

Both fields are additive and have safe defaults — existing rows transparently become "not ignored".

## API

All four classification routes (`POST /api/images/{id}/cve-classifications`, `PUT /api/images/{id}/cve-classifications/{cveId}`, `POST /api/images/name/{name}/cve-classifications`, `POST /api/scans/{id}/cve-classifications`) now accept `isIgnored` and `ignoreReason` in their zod validators. Existing FP-only callers keep working unchanged because the new fields default to `false` / `null`.

The audit logger split distinguishes the two cases:

- `"Marked CVE-2025-X as false positive for image:tag"` — when `isFalsePositive` is true
- `"Ignored CVE-2025-X on image:tag (reason: \"awaiting upstream patch\")"` — when `isIgnored` is true

`details` blob always carries both flags so log consumers can filter on either.

## UI

`CveClassificationDialog` gets a second checkbox plus a reason input that only shows when "Ignore" is checked. Reason is optional but recommended (matches what `.trivyignore` and grype's config typically look like in real-world ops setups — risk acceptance with a note explaining why).

`VulnerabilitiesTab` rows now show an "Ignored" badge alongside the existing "FP" badge, and ignored rows get the same `opacity-50` dim treatment FPs already had.

`ScanDetailsNormalized` takes a new optional `showIgnored` prop (default `false`) — the normalized view filters ignored vulns out of the default list. The parent scan page wires it to local React state so a future UI toggle next to "Show false positives" is a one-line change.

## Things I deliberately left out (flagging up-front)

- **Global `/api/vulnerabilities` list still includes ignored ones.** Filtering at the global aggregator layer needs a product-shape decision: should the cross-image vuln list show a CVE if it's ignored on *some* images but not others? Should there be a per-row "ignored on N/M images" indicator? I'd rather get your read on that than guess. The new index is sized for whatever filter we land on.
- **No bulk "ignore this CVE across all images" path.** The issue specifically said "preferably by doing an Affected Image + CVE ID combo", so I matched that granularity. Happy to add a bulk endpoint as a follow-up if you want.
- **No expiry-based auto-restore.** Often nice ("ignore for 30 days then re-surface so I review again"). Doable on top of this schema by adding a third nullable `ignoreExpiresAt` column — left out to keep the PR small.

## Verification

- `npx prisma generate` clean
- `npx tsc --noEmit` clean (full type-check)
- `npm run test:build` passes
- Manually traced the dialog → API → DB write → re-fetch → row-render path on a stub scan; the new badge shows and the row drops out of the default list when ignored.

Migration file is ready to drop into `prisma/migrations/` — no manual SQL needed.