### PR TITLE
feat(notifications): webhook notifier on new vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ Harbor Guard supports comprehensive configuration through environment variables.
 | `APPRISE_API_URL` | Apprise API URL for multi-service notifications | *none* | Valid HTTP/HTTPS URL | `APPRISE_API_URL=https://apprise.example.com` |
 | `APPRISE_CONFIG_KEY` | Apprise configuration key (optional) | *none* | Configuration key string | `APPRISE_CONFIG_KEY=harborguard` |
 | `APPRISE_URLS` | Direct Apprise notification URLs (comma-separated) | *none* | Comma-separated service URLs | `APPRISE_URLS=mailto://user:pass@gmail.com,discord://webhook/...` |
+| `WEBHOOK_NOTIFIER_URL` | Outbound webhook URL — POSTs JSON of newly-discovered vulnerabilities (vs. the prior scan of the same image:tag) | *none* | Valid HTTP/HTTPS URL | `WEBHOOK_NOTIFIER_URL=https://example.com/hooks/harborguard` |
+| `WEBHOOK_NOTIFIER_HEADERS` | Optional JSON object of extra request headers (e.g. auth) | *none* | JSON string | `WEBHOOK_NOTIFIER_HEADERS='{"Authorization":"Bearer xyz"}'` |
+| `WEBHOOK_NOTIFIER_TIMEOUT_MS` | Per-request timeout for the webhook notifier | `10000` | `100-120000` | `WEBHOOK_NOTIFIER_TIMEOUT_MS=5000` |
+| `WEBHOOK_NOTIFIER_ALL_VULNS` | When `true`, fire on every scan even if no new vulns vs. the prior scan | `false` | `true`, `false` | `WEBHOOK_NOTIFIER_ALL_VULNS=true` |
 | `NOTIFY_ON_HIGH_SEVERITY` | Send notifications only for high/critical findings | `true` | `true`, `false` | `NOTIFY_ON_HIGH_SEVERITY=false` |
 | **Monitoring & Health Checks** |
 | `HEALTH_CHECK_ENABLED` | Enable `/api/health` and `/api/ready` endpoints | `true` | `true`, `false` | `HEALTH_CHECK_ENABLED=false` |
@@ -161,6 +165,12 @@ TEAMS_WEBHOOK_URL=https://outlook.office.com/webhook/your-webhook-url
 # APPRISE_API_URL=https://apprise.example.com
 # APPRISE_URLS=discord://webhook/...,mailto://user:pass@gmail.com
 
+# Option 5: Generic outbound webhook for newly-discovered vulnerabilities
+# WEBHOOK_NOTIFIER_URL=https://example.com/hooks/harborguard
+# WEBHOOK_NOTIFIER_HEADERS='{"Authorization":"Bearer xyz"}'
+# WEBHOOK_NOTIFIER_TIMEOUT_MS=10000
+# WEBHOOK_NOTIFIER_ALL_VULNS=false
+
 NOTIFY_ON_HIGH_SEVERITY=true
 CLEANUP_OLD_SCANS_DAYS=60
 HEALTH_CHECK_ENABLED=true
@@ -189,6 +199,44 @@ docker run -p 8080:8080 \
 ```
 
 </details>
+
+### Webhook Notifier Payload
+
+When `WEBHOOK_NOTIFIER_URL` is set, Harbor Guard POSTs JSON to that URL after each successful scan whenever the scan introduces vulnerabilities not present in the most recent prior completed scan of the same `image:tag`. With no prior scan, every current finding is reported as new. By default no request is sent when there is no diff; set `WEBHOOK_NOTIFIER_ALL_VULNS=true` to receive a payload on every scan.
+
+```json
+{
+  "event": "new_vulnerabilities",
+  "scanId": "clxyz123...",
+  "image": "alpine",
+  "tag": "3.20",
+  "repository": "docker.io",
+  "scannedAt": "2026-01-01T00:00:00.000Z",
+  "newVulnerabilities": [
+    {
+      "cveId": "CVE-2024-12345",
+      "severity": "HIGH",
+      "cvssScore": 7.5,
+      "packageName": "openssl",
+      "packageVersion": "3.3.0-r0",
+      "fixedVersion": "3.3.1-r0",
+      "description": "..."
+    }
+  ],
+  "totalVulnerabilities": 17,
+  "comparisonScanId": "clabc456..."
+}
+```
+
+To smoke-test the receiver before enabling Harbor Guard:
+
+```bash
+curl -X POST "$WEBHOOK_NOTIFIER_URL" \
+  -H "Content-Type: application/json" \
+  -d '{"event":"new_vulnerabilities","scanId":"test","image":"alpine","tag":"3.20","repository":null,"scannedAt":"2026-01-01T00:00:00Z","newVulnerabilities":[],"totalVulnerabilities":0,"comparisonScanId":null}'
+```
+
+Transient 5xx responses are retried up to 3 times with exponential backoff; 4xx responses fail immediately. Failures are logged but never block scan completion.
 
 ### Development Setup
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "tailwindcss": "^4",
+        "tsx": "^4.19.2",
         "tw-animate-css": "^1.3.6",
         "typescript": "^5"
       }
@@ -1153,6 +1154,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -6490,6 +6933,48 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -6766,6 +7251,21 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -6843,6 +7343,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/get-uri": {
@@ -8827,6 +9340,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/ret": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
@@ -9511,6 +10034,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tw-animate-css": {
       "version": "1.3.6",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "start": "node scripts/init-database.js && next start -p ${PORT:-3000}",
     "start:dev": "next start",
     "lint": "next lint",
+    "test": "npx tsx --test src/lib/notifiers/*.test.ts",
     "test:build": "npx prisma generate && npx tsc --noEmit",
     "prebuild": "npx prisma generate",
     "db:init": "node scripts/init-database.js",
@@ -81,6 +82,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "tailwindcss": "^4",
+    "tsx": "^4.19.2",
     "tw-animate-css": "^1.3.6",
     "typescript": "^5"
   }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -27,6 +27,15 @@ export interface AppConfig {
   appriseApiUrl?: string;
   appriseConfigKey?: string;
   appriseUrls?: string;
+  // Generic outbound webhook notifier — POSTs JSON describing newly-discovered
+  // vulnerabilities (i.e. CVEs absent from the prior scan of the same image:tag)
+  // to a user-configured URL. See src/lib/notifiers/webhook.ts.
+  webhookNotifierUrl?: string;
+  // Optional JSON object of additional request headers, e.g. `{"Authorization":"Bearer ..."}`.
+  webhookNotifierHeaders?: string;
+  webhookNotifierTimeoutMs?: number;
+  // When true, fire on every scan even if no new vulns vs. the prior scan.
+  webhookNotifierAllVulns: boolean;
   notifyOnHighSeverity: boolean;
   
   // Monitoring
@@ -67,6 +76,12 @@ function parseEnvConfig(): AppConfig {
     appriseApiUrl: process.env.APPRISE_API_URL,
     appriseConfigKey: process.env.APPRISE_CONFIG_KEY,
     appriseUrls: process.env.APPRISE_URLS,
+    webhookNotifierUrl: process.env.WEBHOOK_NOTIFIER_URL,
+    webhookNotifierHeaders: process.env.WEBHOOK_NOTIFIER_HEADERS,
+    webhookNotifierTimeoutMs: process.env.WEBHOOK_NOTIFIER_TIMEOUT_MS
+      ? parseInt(process.env.WEBHOOK_NOTIFIER_TIMEOUT_MS)
+      : undefined,
+    webhookNotifierAllVulns: process.env.WEBHOOK_NOTIFIER_ALL_VULNS?.toLowerCase() === 'true',
     notifyOnHighSeverity: process.env.NOTIFY_ON_HIGH_SEVERITY?.toLowerCase() === 'true',
     
     // Monitoring
@@ -140,7 +155,19 @@ function validateConfig(config: AppConfig): void {
   if (config.appriseApiUrl && !config.appriseApiUrl.startsWith('http')) {
     errors.push('APPRISE_API_URL must start with http:// or https://');
   }
-  
+
+  // Validate webhook notifier configuration
+  if (config.webhookNotifierUrl && !config.webhookNotifierUrl.startsWith('http')) {
+    errors.push('WEBHOOK_NOTIFIER_URL must start with http:// or https://');
+  }
+
+  if (config.webhookNotifierTimeoutMs !== undefined &&
+      (Number.isNaN(config.webhookNotifierTimeoutMs) ||
+       config.webhookNotifierTimeoutMs < 100 ||
+       config.webhookNotifierTimeoutMs > 120000)) {
+    errors.push('WEBHOOK_NOTIFIER_TIMEOUT_MS must be a number between 100 and 120000');
+  }
+
   if (errors.length > 0) {
     console.error('[CONFIG] Configuration validation errors:');
     errors.forEach(error => console.error(`[CONFIG] - ${error}`));

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -5,6 +5,7 @@
 
 import { config } from './config';
 import { logger } from './logger';
+import { webhookNotifier, type WebhookScanContext } from './notifiers/webhook';
 import { getSeverityHashColor } from './utils/severity-utils';
 
 interface NotificationPayload {
@@ -402,11 +403,12 @@ export class NotificationService {
   async notifyScanComplete(
     imageName: string,
     scanId: string,
-    vulnerabilities: { critical: number; high: number; medium: number; low: number }
+    vulnerabilities: { critical: number; high: number; medium: number; low: number },
+    webhookContext?: { context: WebhookScanContext; imageId: string }
   ): Promise<void> {
     if (vulnerabilities.critical > 0 || vulnerabilities.high > 0) {
       const severity = vulnerabilities.critical > 0 ? 'critical' : 'high';
-      
+
       await this.sendNotification({
         title: 'High-Risk Vulnerabilities Detected',
         message: `Scan completed for ${imageName} with ${vulnerabilities.critical + vulnerabilities.high} high-risk vulnerabilities found.`,
@@ -415,6 +417,20 @@ export class NotificationService {
         imageName,
         vulnerabilityCount: vulnerabilities
       });
+    }
+
+    // The webhook notifier runs on every completed scan (when configured) — its
+    // own internal diff-vs-prior-scan logic decides whether to actually fire.
+    // It is intentionally not gated on `notifyOnHighSeverity` because users
+    // wiring a webhook into automation may want to track every new finding,
+    // including medium/low severity drift between scans.
+    if (webhookContext && config.webhookNotifierUrl) {
+      try {
+        await webhookNotifier.notify(webhookContext.context, webhookContext.imageId);
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        logger.error('Webhook notifier dispatch failed:', errorMessage);
+      }
     }
   }
 

--- a/src/lib/notifiers/webhook.test.ts
+++ b/src/lib/notifiers/webhook.test.ts
@@ -1,0 +1,448 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer, type Server } from 'node:http';
+import { AddressInfo } from 'node:net';
+
+import {
+  WebhookNotifier,
+  computeNewVulnerabilities,
+  loadPriorScanCves,
+  postWebhook,
+  type WebhookPrismaShim,
+} from './webhook';
+
+type Finding = {
+  cveId: string;
+  severity: string;
+  cvssScore: number | null;
+  packageName: string;
+  installedVersion: string | null;
+  fixedVersion: string | null;
+  description: string | null;
+};
+
+function findingsFor(...cveIds: string[]): Finding[] {
+  return cveIds.map(id => ({
+    cveId: id,
+    severity: 'HIGH',
+    cvssScore: 7.5,
+    packageName: 'pkg',
+    installedVersion: '1.0.0',
+    fixedVersion: '1.0.1',
+    description: 'desc',
+  }));
+}
+
+function shim(opts: {
+  priorScanId?: string;
+  priorFindings?: Finding[];
+  currentFindings: Finding[];
+}): WebhookPrismaShim {
+  return {
+    scan: {
+      async findFirst() {
+        return opts.priorScanId ? { id: opts.priorScanId } : null;
+      },
+    },
+    scanVulnerabilityFinding: {
+      async findMany(args) {
+        if (opts.priorScanId && args.where.scanId === opts.priorScanId) {
+          return opts.priorFindings ?? [];
+        }
+        return opts.currentFindings;
+      },
+    },
+  };
+}
+
+async function withServer(
+  handler: (req: import('http').IncomingMessage, res: import('http').ServerResponse) => void,
+  fn: (url: string) => Promise<void>,
+): Promise<void> {
+  const server: Server = createServer(handler);
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  try {
+    await fn(`http://127.0.0.1:${port}/`);
+  } finally {
+    await new Promise<void>(resolve => server.close(() => resolve()));
+  }
+}
+
+describe('computeNewVulnerabilities', () => {
+  test('returns all current findings when there is no prior scan', () => {
+    const current = findingsFor('CVE-1', 'CVE-2', 'CVE-3');
+    const result = computeNewVulnerabilities(current, null);
+    assert.equal(result.length, 3);
+    assert.deepEqual(result.map(v => v.cveId).sort(), ['CVE-1', 'CVE-2', 'CVE-3']);
+    // packageVersion is sourced from installedVersion in the shape mapper
+    assert.equal(result[0].packageVersion, '1.0.0');
+  });
+
+  test('returns only the diff vs the prior scan', () => {
+    const current = findingsFor('CVE-1', 'CVE-2', 'CVE-3');
+    const prior = new Set(['CVE-1', 'CVE-3']);
+    const result = computeNewVulnerabilities(current, prior);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].cveId, 'CVE-2');
+  });
+
+  test('returns empty array when current ⊆ prior', () => {
+    const current = findingsFor('CVE-1', 'CVE-2');
+    const prior = new Set(['CVE-1', 'CVE-2', 'CVE-3']);
+    assert.deepEqual(computeNewVulnerabilities(current, prior), []);
+  });
+});
+
+describe('loadPriorScanCves', () => {
+  test('returns null when no prior scan exists', async () => {
+    const client = shim({ currentFindings: [] });
+    const result = await loadPriorScanCves(client, 'image-1', 'latest', 'scan-current');
+    assert.equal(result, null);
+  });
+
+  test('returns the prior scan id and its CVE set', async () => {
+    const client = shim({
+      priorScanId: 'scan-prior',
+      priorFindings: findingsFor('CVE-X', 'CVE-Y'),
+      currentFindings: [],
+    });
+    const result = await loadPriorScanCves(client, 'image-1', 'latest', 'scan-current');
+    assert.notEqual(result, null);
+    assert.equal(result!.priorScanId, 'scan-prior');
+    assert.deepEqual([...result!.cves].sort(), ['CVE-X', 'CVE-Y']);
+  });
+});
+
+describe('postWebhook', () => {
+  test('returns true on a 2xx response', async () => {
+    await withServer(
+      (_req, res) => {
+        res.writeHead(200);
+        res.end();
+      },
+      async url => {
+        const ok = await postWebhook(url, {}, '{}', 5000);
+        assert.equal(ok, true);
+      },
+    );
+  });
+
+  test('does not retry on 4xx; returns false', async () => {
+    let attempts = 0;
+    await withServer(
+      (_req, res) => {
+        attempts += 1;
+        res.writeHead(401);
+        res.end();
+      },
+      async url => {
+        const ok = await postWebhook(url, {}, '{}', 5000);
+        assert.equal(ok, false);
+        assert.equal(attempts, 1);
+      },
+    );
+  });
+
+  test('retries on 5xx and eventually succeeds', async () => {
+    let attempts = 0;
+    await withServer(
+      (_req, res) => {
+        attempts += 1;
+        if (attempts < 3) {
+          res.writeHead(503);
+          res.end();
+          return;
+        }
+        res.writeHead(200);
+        res.end();
+      },
+      async url => {
+        const ok = await postWebhook(url, {}, '{}', 5000);
+        assert.equal(ok, true);
+        assert.equal(attempts, 3);
+      },
+    );
+  });
+
+  test('retries on 5xx up to 4 attempts and reports failure', async () => {
+    let attempts = 0;
+    await withServer(
+      (_req, res) => {
+        attempts += 1;
+        res.writeHead(500);
+        res.end();
+      },
+      async url => {
+        const ok = await postWebhook(url, {}, '{}', 5000);
+        assert.equal(ok, false);
+        assert.equal(attempts, 4);
+      },
+    );
+  });
+
+  test('forwards extra headers', async () => {
+    let seenAuth: string | undefined;
+    await withServer(
+      (req, res) => {
+        seenAuth = req.headers.authorization;
+        res.writeHead(200);
+        res.end();
+      },
+      async url => {
+        await postWebhook(url, { Authorization: 'Bearer xyz' }, '{}', 5000);
+        assert.equal(seenAuth, 'Bearer xyz');
+      },
+    );
+  });
+
+  test('aborts on timeout and reports failure', async () => {
+    await withServer(
+      (_req, res) => {
+        // Hold the connection open past the timeout. Never end the response.
+        setTimeout(() => res.end(), 5000);
+      },
+      async url => {
+        const ok = await postWebhook(url, {}, '{}', 100);
+        assert.equal(ok, false);
+      },
+    );
+  });
+});
+
+describe('WebhookNotifier.notify', () => {
+  test('skips when no URL is configured (returns true, makes no HTTP call)', async () => {
+    let called = false;
+    const fakeFetch = (async () => {
+      called = true;
+      return new Response('', { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const notifier = new WebhookNotifier(
+      shim({ currentFindings: findingsFor('CVE-1') }),
+      fakeFetch,
+      { url: undefined, headers: {}, timeoutMs: 5000, allVulns: false },
+    );
+    const ok = await notifier.notify(
+      {
+        scanId: 'scan-1',
+        image: 'alpine',
+        tag: 'latest',
+        registry: undefined,
+        scannedAt: new Date('2026-01-01T00:00:00Z'),
+      },
+      'image-1',
+    );
+    assert.equal(ok, true);
+    assert.equal(called, false);
+  });
+
+  test('no prior scan → all current vulns reported as new', async () => {
+    let received: any;
+    await withServer(
+      (req, res) => {
+        let body = '';
+        req.on('data', chunk => (body += chunk));
+        req.on('end', () => {
+          received = JSON.parse(body);
+          res.writeHead(200);
+          res.end();
+        });
+      },
+      async url => {
+        const notifier = new WebhookNotifier(
+          shim({ currentFindings: findingsFor('CVE-1', 'CVE-2') }),
+          fetch,
+          { url, headers: {}, timeoutMs: 5000, allVulns: false },
+        );
+        const ok = await notifier.notify(
+          {
+            scanId: 'scan-1',
+            image: 'alpine',
+            tag: '3.20',
+            registry: 'docker.io',
+            scannedAt: new Date('2026-01-01T00:00:00Z'),
+          },
+          'image-1',
+        );
+        assert.equal(ok, true);
+        assert.equal(received.event, 'new_vulnerabilities');
+        assert.equal(received.scanId, 'scan-1');
+        assert.equal(received.image, 'alpine');
+        assert.equal(received.tag, '3.20');
+        assert.equal(received.repository, 'docker.io');
+        assert.equal(received.totalVulnerabilities, 2);
+        assert.equal(received.comparisonScanId, null);
+        assert.equal(received.newVulnerabilities.length, 2);
+      },
+    );
+  });
+
+  test('prior scan with overlap → only new CVEs reported', async () => {
+    let received: any;
+    await withServer(
+      (req, res) => {
+        let body = '';
+        req.on('data', chunk => (body += chunk));
+        req.on('end', () => {
+          received = JSON.parse(body);
+          res.writeHead(200);
+          res.end();
+        });
+      },
+      async url => {
+        const notifier = new WebhookNotifier(
+          shim({
+            priorScanId: 'scan-prior',
+            priorFindings: findingsFor('CVE-1', 'CVE-3'),
+            currentFindings: findingsFor('CVE-1', 'CVE-2', 'CVE-4'),
+          }),
+          fetch,
+          { url, headers: {}, timeoutMs: 5000, allVulns: false },
+        );
+        const ok = await notifier.notify(
+          {
+            scanId: 'scan-1',
+            image: 'alpine',
+            tag: '3.20',
+            scannedAt: new Date('2026-01-01T00:00:00Z'),
+          },
+          'image-1',
+        );
+        assert.equal(ok, true);
+        assert.equal(received.totalVulnerabilities, 3);
+        assert.equal(received.comparisonScanId, 'scan-prior');
+        assert.deepEqual(
+          received.newVulnerabilities.map((v: any) => v.cveId).sort(),
+          ['CVE-2', 'CVE-4'],
+        );
+      },
+    );
+  });
+
+  test('no new vulns + ALL_VULNS=false → no notification fired', async () => {
+    let called = 0;
+    const fakeFetch = (async () => {
+      called += 1;
+      return new Response('', { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const notifier = new WebhookNotifier(
+      shim({
+        priorScanId: 'scan-prior',
+        priorFindings: findingsFor('CVE-1', 'CVE-2'),
+        currentFindings: findingsFor('CVE-1', 'CVE-2'),
+      }),
+      fakeFetch,
+      { url: 'http://example.invalid/', headers: {}, timeoutMs: 5000, allVulns: false },
+    );
+    const ok = await notifier.notify(
+      {
+        scanId: 'scan-1',
+        image: 'alpine',
+        tag: '3.20',
+        scannedAt: new Date('2026-01-01T00:00:00Z'),
+      },
+      'image-1',
+    );
+    assert.equal(ok, true);
+    assert.equal(called, 0);
+  });
+
+  test('no new vulns + ALL_VULNS=true → still fires with empty newVulnerabilities', async () => {
+    let received: any;
+    await withServer(
+      (req, res) => {
+        let body = '';
+        req.on('data', chunk => (body += chunk));
+        req.on('end', () => {
+          received = JSON.parse(body);
+          res.writeHead(200);
+          res.end();
+        });
+      },
+      async url => {
+        const notifier = new WebhookNotifier(
+          shim({
+            priorScanId: 'scan-prior',
+            priorFindings: findingsFor('CVE-1'),
+            currentFindings: findingsFor('CVE-1'),
+          }),
+          fetch,
+          { url, headers: {}, timeoutMs: 5000, allVulns: true },
+        );
+        const ok = await notifier.notify(
+          {
+            scanId: 'scan-1',
+            image: 'alpine',
+            tag: '3.20',
+            scannedAt: new Date('2026-01-01T00:00:00Z'),
+          },
+          'image-1',
+        );
+        assert.equal(ok, true);
+        assert.equal(received.totalVulnerabilities, 1);
+        assert.equal(received.newVulnerabilities.length, 0);
+        assert.equal(received.comparisonScanId, 'scan-prior');
+      },
+    );
+  });
+
+  test('5xx with retries exhausted → returns false but does not throw', async () => {
+    let attempts = 0;
+    await withServer(
+      (_req, res) => {
+        attempts += 1;
+        res.writeHead(503);
+        res.end();
+      },
+      async url => {
+        const notifier = new WebhookNotifier(
+          shim({ currentFindings: findingsFor('CVE-1') }),
+          fetch,
+          { url, headers: {}, timeoutMs: 1000, allVulns: false },
+        );
+        const ok = await notifier.notify(
+          {
+            scanId: 'scan-1',
+            image: 'alpine',
+            tag: '3.20',
+            scannedAt: new Date(),
+          },
+          'image-1',
+        );
+        assert.equal(ok, false);
+        assert.equal(attempts, 4);
+      },
+    );
+  });
+
+  test('4xx → no retry, returns false', async () => {
+    let attempts = 0;
+    await withServer(
+      (_req, res) => {
+        attempts += 1;
+        res.writeHead(401);
+        res.end();
+      },
+      async url => {
+        const notifier = new WebhookNotifier(
+          shim({ currentFindings: findingsFor('CVE-1') }),
+          fetch,
+          { url, headers: {}, timeoutMs: 1000, allVulns: false },
+        );
+        const ok = await notifier.notify(
+          {
+            scanId: 'scan-1',
+            image: 'alpine',
+            tag: '3.20',
+            scannedAt: new Date(),
+          },
+          'image-1',
+        );
+        assert.equal(ok, false);
+        assert.equal(attempts, 1);
+      },
+    );
+  });
+});

--- a/src/lib/notifiers/webhook.ts
+++ b/src/lib/notifiers/webhook.ts
@@ -1,0 +1,345 @@
+/**
+ * Generic outbound webhook notifier.
+ *
+ * Posts a structured JSON payload to a user-configured URL whenever a scan
+ * run produces vulnerabilities that were not present in the most recent
+ * prior completed scan of the same image:tag. The diff-against-prior
+ * behaviour is the point of this notifier: existing notifiers (Teams,
+ * Slack, Gotify, Apprise, Discord, ntfy) deliver human-readable summaries
+ * for every high-severity scan; this one delivers a machine-readable feed
+ * of *new* findings so users can wire it into their own automation
+ * (ticketing, SIEM, on-call paging, etc.) without re-parsing summary text.
+ *
+ * Configured via four env vars, all optional:
+ *   WEBHOOK_NOTIFIER_URL          — destination URL; absence disables the notifier
+ *   WEBHOOK_NOTIFIER_HEADERS      — JSON object of extra headers (e.g. auth)
+ *   WEBHOOK_NOTIFIER_TIMEOUT_MS   — per-request timeout, default 10000
+ *   WEBHOOK_NOTIFIER_ALL_VULNS    — `true` to fire on every scan even when
+ *                                   no new vulns vs. prior scan (default off)
+ *
+ * Transport behaviour: 3 retries with exponential backoff on transient
+ * failures (5xx + network errors); 4xx responses fail fast with no retry.
+ */
+
+import { config } from '../config';
+import { logger } from '../logger';
+import { prisma } from '../prisma';
+
+const DEFAULT_TIMEOUT_MS = 10000;
+const MAX_ATTEMPTS = 4; // 1 initial + 3 retries
+const BASE_BACKOFF_MS = 500;
+
+export interface WebhookScanContext {
+  scanId: string;
+  image: string;
+  tag: string;
+  registry?: string;
+  scannedAt: Date;
+}
+
+export interface WebhookVulnerability {
+  cveId: string;
+  severity: string;
+  cvssScore: number | null;
+  packageName: string;
+  packageVersion: string | null;
+  fixedVersion: string | null;
+  description: string | null;
+}
+
+export interface WebhookPayload {
+  event: 'new_vulnerabilities';
+  scanId: string;
+  image: string;
+  tag: string;
+  repository: string | null;
+  scannedAt: string;
+  newVulnerabilities: WebhookVulnerability[];
+  totalVulnerabilities: number;
+  comparisonScanId: string | null;
+}
+
+export interface WebhookNotifierOptions {
+  url?: string;
+  headers?: Record<string, string>;
+  timeoutMs?: number;
+  allVulns?: boolean;
+}
+
+interface PriorScanQuery {
+  findFirst(args: {
+    where: { imageId: string; tag: string; status: 'SUCCESS'; id: { not: string } };
+    orderBy: { finishedAt: 'desc' };
+    select: { id: true };
+  }): Promise<{ id: string } | null>;
+}
+
+interface VulnerabilityFindingQuery {
+  findMany(args: {
+    where: { scanId: string };
+    select: {
+      cveId: true;
+      severity: true;
+      cvssScore: true;
+      packageName: true;
+      installedVersion: true;
+      fixedVersion: true;
+      description: true;
+    };
+  }): Promise<Array<{
+    cveId: string;
+    severity: string;
+    cvssScore: number | null;
+    packageName: string;
+    installedVersion: string | null;
+    fixedVersion: string | null;
+    description: string | null;
+  }>>;
+}
+
+export interface WebhookPrismaShim {
+  scan: PriorScanQuery;
+  scanVulnerabilityFinding: VulnerabilityFindingQuery;
+}
+
+/**
+ * Fetch the most recent successfully-completed prior scan for the same
+ * image:tag (excluding the current scan), and return its set of CVE IDs.
+ * Returns null when no prior scan exists.
+ */
+export async function loadPriorScanCves(
+  client: WebhookPrismaShim,
+  imageId: string,
+  tag: string,
+  currentScanId: string,
+): Promise<{ priorScanId: string; cves: Set<string> } | null> {
+  const prior = await client.scan.findFirst({
+    where: { imageId, tag, status: 'SUCCESS', id: { not: currentScanId } },
+    orderBy: { finishedAt: 'desc' },
+    select: { id: true },
+  });
+  if (!prior) return null;
+
+  const findings = await client.scanVulnerabilityFinding.findMany({
+    where: { scanId: prior.id },
+    select: {
+      cveId: true,
+      severity: true,
+      cvssScore: true,
+      packageName: true,
+      installedVersion: true,
+      fixedVersion: true,
+      description: true,
+    },
+  });
+
+  return {
+    priorScanId: prior.id,
+    cves: new Set(findings.map(f => f.cveId)),
+  };
+}
+
+/**
+ * Compute the set of "new" vulnerabilities — the findings present in the
+ * current scan that were not present in the prior scan. With no prior
+ * scan, every current finding is new.
+ */
+export function computeNewVulnerabilities(
+  current: Array<{
+    cveId: string;
+    severity: string;
+    cvssScore: number | null;
+    packageName: string;
+    installedVersion: string | null;
+    fixedVersion: string | null;
+    description: string | null;
+  }>,
+  priorCves: Set<string> | null,
+): WebhookVulnerability[] {
+  const novel = priorCves
+    ? current.filter(f => !priorCves.has(f.cveId))
+    : current;
+
+  return novel.map(f => ({
+    cveId: f.cveId,
+    severity: f.severity,
+    cvssScore: f.cvssScore,
+    packageName: f.packageName,
+    packageVersion: f.installedVersion,
+    fixedVersion: f.fixedVersion,
+    description: f.description,
+  }));
+}
+
+/**
+ * POST the payload with timeout + retry. Retries 5xx and network errors
+ * up to MAX_ATTEMPTS with exponential backoff; 4xx responses are
+ * permanent and fail immediately. Returns true on a 2xx, false otherwise.
+ *
+ * Fetch is taken as a parameter to make the function unit-testable
+ * without monkey-patching globals.
+ */
+export async function postWebhook(
+  url: string,
+  headers: Record<string, string>,
+  body: string,
+  timeoutMs: number,
+  fetchImpl: typeof fetch = fetch,
+): Promise<boolean> {
+  let lastError: string | null = null;
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const response = await fetchImpl(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...headers,
+        },
+        body,
+        signal: controller.signal,
+      });
+      clearTimeout(timer);
+
+      if (response.ok) return true;
+
+      // 4xx — permanent. Don't retry.
+      if (response.status >= 400 && response.status < 500) {
+        logger.error(
+          `Webhook notifier: ${response.status} ${response.statusText} (no retry on 4xx)`,
+        );
+        return false;
+      }
+
+      lastError = `${response.status} ${response.statusText}`;
+    } catch (err) {
+      clearTimeout(timer);
+      lastError = err instanceof Error ? err.message : String(err);
+    }
+
+    if (attempt < MAX_ATTEMPTS) {
+      const delay = BASE_BACKOFF_MS * 2 ** (attempt - 1);
+      await new Promise(resolve => setTimeout(resolve, delay));
+    }
+  }
+
+  logger.error(`Webhook notifier: giving up after ${MAX_ATTEMPTS} attempts (${lastError})`);
+  return false;
+}
+
+/**
+ * Parse WEBHOOK_NOTIFIER_HEADERS as a JSON object. Returns an empty
+ * object on failure with a warning logged — bad config should not block
+ * notifications, just strip the broken auth header.
+ */
+function parseHeaders(raw: string | undefined): Record<string, string> {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      const out: Record<string, string> = {};
+      for (const [k, v] of Object.entries(parsed)) {
+        if (typeof v === 'string') out[k] = v;
+      }
+      return out;
+    }
+    logger.warn('WEBHOOK_NOTIFIER_HEADERS is not a JSON object; ignoring.');
+    return {};
+  } catch {
+    logger.warn('WEBHOOK_NOTIFIER_HEADERS is not valid JSON; ignoring.');
+    return {};
+  }
+}
+
+function readOptionsFromConfig(): WebhookNotifierOptions {
+  return {
+    url: config.webhookNotifierUrl,
+    headers: parseHeaders(config.webhookNotifierHeaders),
+    timeoutMs: config.webhookNotifierTimeoutMs ?? DEFAULT_TIMEOUT_MS,
+    allVulns: !!config.webhookNotifierAllVulns,
+  };
+}
+
+export class WebhookNotifier {
+  constructor(
+    private readonly client: WebhookPrismaShim = prisma as unknown as WebhookPrismaShim,
+    private readonly fetchImpl: typeof fetch = fetch,
+    private readonly options: WebhookNotifierOptions = readOptionsFromConfig(),
+  ) {}
+
+  /**
+   * Fire the webhook for a completed scan. Returns true on a successful
+   * delivery (2xx) or when the call is intentionally skipped (no diff,
+   * no URL configured); returns false on a non-recoverable transport
+   * failure. Never throws — failures are logged but do not block scan
+   * completion.
+   */
+  async notify(
+    context: WebhookScanContext,
+    imageId: string,
+  ): Promise<boolean> {
+    const { url, headers = {}, timeoutMs = DEFAULT_TIMEOUT_MS, allVulns = false } = this.options;
+
+    if (!url) return true;
+
+    try {
+      const currentFindings = await this.client.scanVulnerabilityFinding.findMany({
+        where: { scanId: context.scanId },
+        select: {
+          cveId: true,
+          severity: true,
+          cvssScore: true,
+          packageName: true,
+          installedVersion: true,
+          fixedVersion: true,
+          description: true,
+        },
+      });
+
+      const prior = await loadPriorScanCves(this.client, imageId, context.tag, context.scanId);
+      const newVulns = computeNewVulnerabilities(currentFindings, prior?.cves ?? null);
+
+      if (newVulns.length === 0 && !allVulns) {
+        logger.debug(
+          `Webhook notifier: no new vulnerabilities for ${context.image}:${context.tag} vs prior scan, skipping.`,
+        );
+        return true;
+      }
+
+      const payload: WebhookPayload = {
+        event: 'new_vulnerabilities',
+        scanId: context.scanId,
+        image: context.image,
+        tag: context.tag,
+        repository: context.registry ?? null,
+        scannedAt: context.scannedAt.toISOString(),
+        newVulnerabilities: newVulns,
+        totalVulnerabilities: currentFindings.length,
+        comparisonScanId: prior?.priorScanId ?? null,
+      };
+
+      const ok = await postWebhook(
+        url,
+        headers,
+        JSON.stringify(payload),
+        timeoutMs,
+        this.fetchImpl,
+      );
+      if (ok) {
+        logger.webhook(
+          `Successfully sent webhook notifier (${newVulns.length} new of ${currentFindings.length} total)`,
+        );
+      }
+      return ok;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.error('Webhook notifier failed:', msg);
+      return false;
+    }
+  }
+}
+
+export const webhookNotifier = new WebhookNotifier();

--- a/src/lib/scanner/ScannerService.ts
+++ b/src/lib/scanner/ScannerService.ts
@@ -159,15 +159,25 @@ export class ScannerService {
         this.updateJobStatus(requestId, 'RUNNING', 90, undefined, 'Storing results');
         await ingestEnvelope(scanId, envelope);
 
-        // Send notifications
-        const { critical, high } = envelope.aggregates.vulnerabilityCounts;
-        if (critical > 0 || high > 0) {
-          await notificationService.notifyScanComplete(
-            `${request.image}:${request.tag}`,
-            scanId,
-            envelope.aggregates.vulnerabilityCounts,
-          );
-        }
+        // Send notifications. Internally, notifyScanComplete only fires the
+        // human-readable notifiers (Teams/Slack/etc.) on critical/high counts,
+        // but always runs the webhook notifier (when configured) so the diff
+        // vs. the prior scan can include medium/low drift.
+        await notificationService.notifyScanComplete(
+          `${request.image}:${request.tag}`,
+          scanId,
+          envelope.aggregates.vulnerabilityCounts,
+          {
+            imageId,
+            context: {
+              scanId,
+              image: request.image,
+              tag: request.tag,
+              registry: request.registry,
+              scannedAt: new Date(),
+            },
+          },
+        );
 
         this.updateJobStatus(requestId, 'SUCCESS', 100, undefined, 'Scan completed successfully');
         await scanQueue.completeScan(requestId);


### PR DESCRIPTION
Implements a webhook notifier from the notifier-extensibility track (follow-up to #186).

The existing notifiers (Teams, Slack, Gotify, Apprise, Discord, ntfy) deliver human-readable summaries gated on high/critical counts. This adds a generic outbound webhook that POSTs structured JSON describing newly-discovered vulnerabilities, so users can wire scan output into ticketing / SIEM / on-call without parsing summary strings.

## What "new" means

After each successful scan, the notifier:

1. Looks up the most recent prior `Scan` of the same `imageId` + `tag` with `status = SUCCESS`, excluding the current scan.
2. Collects that prior scan's `ScanVulnerabilityFinding.cveId` values into a `Set`.
3. Filters the current scan's findings against that set — anything missing from the prior scan is "new".
4. With no prior scan, every current finding is treated as new.
5. With no diff and `WEBHOOK_NOTIFIER_ALL_VULNS=false` (default), no request is sent.

The webhook fires regardless of `notifyOnHighSeverity` — users wiring this into automation typically want to track medium/low drift between scans, not only critical/high spikes.

## Payload

```json
{
  "event": "new_vulnerabilities",
  "scanId": "clxyz123...",
  "image": "alpine",
  "tag": "3.20",
  "repository": "docker.io",
  "scannedAt": "2026-01-01T00:00:00.000Z",
  "newVulnerabilities": [
    {
      "cveId": "CVE-2024-12345",
      "severity": "HIGH",
      "cvssScore": 7.5,
      "packageName": "openssl",
      "packageVersion": "3.3.0-r0",
      "fixedVersion": "3.3.1-r0",
      "description": "..."
    }
  ],
  "totalVulnerabilities": 17,
  "comparisonScanId": "clabc456..."
}
```

`comparisonScanId` is `null` when there is no prior scan to diff against.

## Configuration

| Variable | Default | Notes |
|---|---|---|
| `WEBHOOK_NOTIFIER_URL` | unset | Destination URL. Absence disables the notifier. |
| `WEBHOOK_NOTIFIER_HEADERS` | unset | Optional JSON object of extra headers, e.g. `{"Authorization":"Bearer xyz"}`. |
| `WEBHOOK_NOTIFIER_TIMEOUT_MS` | `10000` | Per-request timeout (validated 100–120000). |
| `WEBHOOK_NOTIFIER_ALL_VULNS` | `false` | When `true`, fire on every scan even if no diff vs. the prior scan. |

## Transport

1 + 3 retries with exponential backoff (500ms, 1s, 2s) on 5xx and network errors; 4xx responses fail fast with no retry; per-attempt timeout via `AbortController`. All failures are logged via `logger.error` but never throw out of `notifyScanComplete`, so a broken receiver does not block scan completion.

## Test coverage

`npm test` runs 18 cases via Node's built-in test runner (`node --test`, no new test framework dep — only `tsx` added so TypeScript imports resolve in the runner):

- `computeNewVulnerabilities`: no-prior-scan, partial overlap, and current-is-subset-of-prior cases.
- `loadPriorScanCves`: null when no prior scan, returns prior id + CVE set when one exists.
- `postWebhook`: 2xx success, 4xx no-retry, 5xx retry-then-succeed, 5xx retry-exhaust-fail, header forwarding, abort-on-timeout.
- `WebhookNotifier.notify`: skip-when-no-URL, no-prior-scan path, partial-overlap path, no-diff with `ALL_VULNS=false` (no HTTP call), no-diff with `ALL_VULNS=true` (fires with empty `newVulnerabilities`), 5xx retry exhaustion returns false without throwing, 4xx returns false without retrying.

The HTTP-path tests use a real in-process `http.createServer` rather than mocking `fetch`, so the timeout and retry behaviour exercises actual `AbortController` + `fetch` semantics.

## Smoke-test the receiver

```bash
curl -X POST "$WEBHOOK_NOTIFIER_URL" \
  -H "Content-Type: application/json" \
  -d '{"event":"new_vulnerabilities","scanId":"test","image":"alpine","tag":"3.20","repository":null,"scannedAt":"2026-01-01T00:00:00Z","newVulnerabilities":[],"totalVulnerabilities":0,"comparisonScanId":null}'
```

## Files

- `src/lib/notifiers/webhook.ts` — new, ~270 lines incl. comments.
- `src/lib/notifiers/webhook.test.ts` — new, 18 cases.
- `src/lib/notifications.ts` — extends `notifyScanComplete` with an optional webhook context arg; the webhook dispatch runs independently of the high-severity gate.
- `src/lib/scanner/ScannerService.ts` — passes `imageId`, `image`, `tag`, `registry` into `notifyScanComplete`; removes the `critical || high` gate around the call (the human notifiers still gate themselves internally).
- `src/lib/config.ts` — four env vars + URL/timeout validation.
- `package.json` — `tsx` dev-dep + `npm test` script (uses `npx tsx --test`, no new runtime deps).
- `README.md` — notifier table row + payload example + curl smoke-test.

## Verification

- `npx tsc --noEmit` clean
- `npm test` — 18 / 18 pass
- `npm run build` (full Next + Prisma generate + OpenAPI) clean